### PR TITLE
Users cant order out of time restraints

### DIFF
--- a/website/orders/views.py
+++ b/website/orders/views.py
@@ -61,8 +61,6 @@ class OrderView(LoginRequiredMixin, TemplateView):
             return "You can not order more products"
         if not product.user_can_order_amount(user, shift):
             return "You can not order more {}".format(product.name)
-        if not shift.can_order:
-            return "You can not order products for this shift"
         if not product.available:
             return "Product {} is not available".format(product.name)
         return True
@@ -79,6 +77,10 @@ class OrderView(LoginRequiredMixin, TemplateView):
         """
         if not shift.user_can_order_amount(user, amount=len(order_list)):
             return "You can't order that much products in this shift"
+        if not shift.can_order:
+            return "You can not order products for this shift"
+        if not shift.is_active:
+            return "This shift is not active"
         for order in order_list:
             error_msg = OrderView.can_order(shift, order, user)
             if isinstance(error_msg, str):


### PR DESCRIPTION
Fixed two issues:

- An issue where users could order even before or after the time of the shift.
- An issue where the admin backend would not save a shift when changing the timespan out of an already placed order.

Closes #58 