### PR TITLE
Added permissions to Shift admin views if user is not in the assignees

### DIFF
--- a/website/orders/api/v1/permissions.py
+++ b/website/orders/api/v1/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsOnBakersList(BasePermission):
+    """Permission for checking if a user is on the bakers list of a Shift."""
+
+    def has_permission(self, request, view):
+        """Check if a user has a certain object permissions."""
+        shift = view.get_shift()
+        return request.user in shift.get_assignees()

--- a/website/orders/api/v1/urls.py
+++ b/website/orders/api/v1/urls.py
@@ -13,6 +13,7 @@ from orders.api.v1.views import (
     ProductSearchAPIView,
     OrderTogglePaidAPIView,
     OrderToggleReadyAPIView,
+    JoinShiftAPIView,
 )
 from orders.converters import ShiftConverter, OrderConverter
 
@@ -36,4 +37,5 @@ urlpatterns = [
     path("shifts/<shift:shift>/cart-order", CartOrderAPIView.as_view(), name="shifts_cart_order"),
     path("shifts/<shift:shift>/products", ProductListAPIView.as_view(), name="product_list"),
     path("shifts/<shift:shift>/search", ProductSearchAPIView.as_view(), name="product_search"),
+    path("shifts/<shift:shift>/join", JoinShiftAPIView.as_view(), name="join_shift"),
 ]

--- a/website/orders/templates/orders/shift_admin_footer.html
+++ b/website/orders/templates/orders/shift_admin_footer.html
@@ -97,14 +97,14 @@
                             </div>
                         </a>
                     </div>
-                    <div class="col expand-mobile">
-                        <div class="h-100 btn-ml btn-on m-auto w-100" id="overview-button" data-toggle="modal"
-                             data-target="#order-overview-popup-{{ shift.id }}">
-                            <p class="font-footer flex-fixed"><i class="fas fa-binoculars"></i></p>
-                            <p class="font-footer">Summary</p>
-                        </div>
-                    </div>
                 {% endif %}
+                <div class="col expand-mobile">
+                    <div class="h-100 btn-ml btn-on m-auto w-100" id="overview-button" data-toggle="modal"
+                         data-target="#order-overview-popup-{{ shift.id }}">
+                        <p class="font-footer flex-fixed"><i class="fas fa-binoculars"></i></p>
+                        <p class="font-footer">Summary</p>
+                    </div>
+                </div>
             </div>
             <button id="footer-toggler" class="navbar-toggler m-auto" style="border: 0" type="button"
                     data-toggle="collapse"

--- a/website/orders/views.py
+++ b/website/orders/views.py
@@ -173,6 +173,8 @@ class ShiftAdminView(PermissionRequiredMixin, TemplateView):
         :return: the Shift admin view page for seeing the current orders of a shift and modifying it
         """
         shift = kwargs.get("shift")
+        if request.user not in shift.get_assignees():
+            return redirect("orders:shift_join", shift=shift)
 
         return render(
             request,


### PR DESCRIPTION
Shift admin actions and views now require the user to be in the assignees of the shift before working. The following has changed:

- The `orders` API now has a new permission: `IsOnBakersList` which checks if the user is on the assignees list of the `Shift`.
- The following API views are now restricted by this permission: 

- `OrderListCreateAPIView` for creating Scanned orders.
- `OrderRetrieveDestoryAPIView` for destroying orders.
- `ShiftRetrieveUpdateAPIView` for updating `Shift`s.
- `ShiftAddTimeAPIView`
- `ShiftAddCapacityAPIView`
- `ShiftScannerAPIView`
- `OrderTogglePaidAPIView`
- `OrderToggleReadyAPIView`

- Also added a `JoinShiftAPIView` for joining the `Shift` as a baker via a PATCH to the new endpoint `shifts/<shift>/join`.
- The `ShiftAdminView` now redirects a user to the `JoinShiftView` if he/she has permission to join the `Shift` but is not yet on the bakers list.

Closes #98 