### PR TITLE
Refactor filters

### DIFF
--- a/website/orders/apps.py
+++ b/website/orders/apps.py
@@ -13,7 +13,14 @@ class OrdersConfig(AppConfig):
         :return: None
         """
         from orders import signals  # noqa
-        from .services import filter_user_page
-        from tosti.filter import function_filter
+        from users.views import AccountView
+        from orders.views import render_ordered_items_tab
 
-        function_filter.add_filter("tabs_user_page", filter_user_page)
+        def filter_user_page(user_page_list: list):
+            """Add Ordered items tab on accounts page."""
+            user_page_list.append(
+                {"name": "Ordered items", "slug": "ordered_items", "renderer": render_ordered_items_tab,}  # noqa
+            )
+            return user_page_list
+
+        AccountView.user_data_tabs.add_filter(filter_user_page)

--- a/website/orders/services.py
+++ b/website/orders/services.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 
 from orders.exceptions import OrderException
 from orders.models import Order, Product, Shift
-import orders.views
 from users.models import User
 
 
@@ -220,11 +219,3 @@ class Cart:
     def to_json(self):
         """Convert this object to JSON."""
         return json.dumps(self.get_item_list_ids())
-
-
-def filter_user_page(user_page_list: list):
-    """Add Ordered items tab on accounts page."""
-    user_page_list.append(
-        {"name": "Ordered items", "slug": "ordered_items", "renderer": orders.views.render_ordered_items_tab,}  # noqa
-    )
-    return user_page_list

--- a/website/thaliedje/apps.py
+++ b/website/thaliedje/apps.py
@@ -8,7 +8,14 @@ class ThaliedjeConfig(AppConfig):
 
     def ready(self):
         """Ready method."""
-        from .services import filter_user_page
-        from tosti.filter import function_filter
+        from users.views import AccountView
+        from thaliedje.views import render_account_history_tab
 
-        function_filter.add_filter("tabs_user_page", filter_user_page)
+        def filter_user_page(user_page_list: list):
+            """Add requested songs as a tab to users page."""
+            user_page_list.append(
+                {"name": "Requested songs", "slug": "requested_songs", "renderer": render_account_history_tab,}  # noqa
+            )
+            return user_page_list
+
+        AccountView.user_data_tabs.add_filter(filter_user_page)

--- a/website/thaliedje/services.py
+++ b/website/thaliedje/services.py
@@ -10,7 +10,6 @@ from thaliedje.models import (
     SpotifyTrack,
     SpotifyQueueItem,
 )
-from thaliedje.views import render_account_history_tab
 
 
 def create_track_database_information(track_info):
@@ -189,11 +188,3 @@ def execute_data_minimisation(dry_run=False):
         if not dry_run:
             request.save()
     return users
-
-
-def filter_user_page(user_page_list: list):
-    """Add requested songs as a tab to users page."""
-    user_page_list.append(
-        {"name": "Requested songs", "slug": "requested_songs", "renderer": render_account_history_tab,}  # noqa
-    )
-    return user_page_list

--- a/website/tosti/filter.py
+++ b/website/tosti/filter.py
@@ -11,38 +11,26 @@ class Filter:
 
     def __init__(self):
         """Initialize."""
-        self.filters = {}
+        self.filters = []
 
-    def add_filter(self, filter_name: str, callback: Callable, place: int = 0):
+    def add_filter(self, callback: Callable, place: int = 0):
         """
         Add a function to a filter with a specified name and place.
 
-        :param filter_name: the filter name to add the callback to
         :param callback: the function to add to the filter name
         :param place: the place in the order to add the function
         :return: None
         """
-        if filter_name in self.filters.keys():
-            self.filters[filter_name].insert(place, callback)
-        else:
-            self.filters[filter_name] = [callback]
+        self.filters.insert(place, callback)
 
-    def do_filter(self, filter_name: str, *args):
+    def do_filter(self, *args):
         """
         Execute a filter by iteratively executing all its registered callbacks.
 
-        :param filter_name: the filter name to execute
         :param args: the arguments to provide to the functions
         :return: filtered arguments
         """
-        if filter_name in self.filters.keys():
-            args_copy = copy.deepcopy(*args)
-            for filter_callback in self.filters[filter_name]:
-                args_copy = filter_callback(args_copy)
-            return args_copy
-        else:
-            return args
-
-
-# The default filter to use
-function_filter = Filter()
+        args_copy = copy.deepcopy(*args)
+        for filter_callback in self.filters:
+            args_copy = filter_callback(args_copy)
+        return args_copy

--- a/website/users/views.py
+++ b/website/users/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views.generic import TemplateView
 
-from tosti.filter import function_filter
+from tosti.filter import Filter
 from .forms import LoginForm, AccountForm
 from .services import get_openid_verifier, update_staff_status
 
@@ -130,6 +130,8 @@ class AccountView(LoginRequiredMixin, TemplateView):
 
     template_name = "users/account.html"
 
+    user_data_tabs = Filter()
+
     def get(self, request, **kwargs):
         """
         GET request for the account view.
@@ -148,7 +150,7 @@ class AccountView(LoginRequiredMixin, TemplateView):
             }
         )
         active = request.GET.get("active", "users")
-        tabs = function_filter.do_filter("tabs_user_page", [])
+        tabs = self.user_data_tabs.do_filter([])
         rendered_tab = None
         for tab in tabs:
             if active == tab["slug"]:
@@ -166,7 +168,7 @@ class AccountView(LoginRequiredMixin, TemplateView):
         :return: a render of the account view
         """
         form = AccountForm(request.POST)
-        tabs = function_filter.do_filter("tabs_user_page", [])
+        tabs = self.user_data_tabs.do_filter([])
         if form.is_valid():
             request.user.profile.association = form.cleaned_data.get("association")
             request.user.profile.save()


### PR DESCRIPTION
My proposal for refactoring the filters. The only change I would still like to add, is to remove the `filter_name` and change the callable that `add_filter` expects to a tuple `name`, `slug` and `renderer`, as I don't see why you would do anything else then appending to the filter list