### PR TITLE
Bootstrap modal auto hide

### DIFF
--- a/website/orders/static/orders/js/admin-scanner.js
+++ b/website/orders/static/orders/js/admin-scanner.js
@@ -106,7 +106,8 @@ function add_product_from_barcode(result) {
             if (typeof (update_refresh_list) !== 'undefined') {
                 update_refresh_list();
             }
-            document.getElementById(POPUP_MODAL_ID).modal('hide');
+            let modal = bootstrap.Modal.getInstance(document.getElementById(POPUP_MODAL_ID));
+            modal.hide();
         }).catch(error => {
             console.log(error);
             console.log("No product data for barcode " + barcode + " .");


### PR DESCRIPTION
Automatically hide modal after scanning a correct barcode. This was broken due to the Bootstrap 5 upgrade.