### PR TITLE
Allow nu.thalia oauth redirect scheme

### DIFF
--- a/website/tosti/settings/base.py
+++ b/website/tosti/settings/base.py
@@ -138,7 +138,7 @@ CORS_URLS_REGEX = r"^/(?:api|user/oauth)/.*"
 
 # OAUTH
 OAUTH2_PROVIDER = {
-    "ALLOWED_REDIRECT_URI_SCHEMES": ["https"],
+    "ALLOWED_REDIRECT_URI_SCHEMES": ["https", "nu.thalia"],
     "SCOPES": {
         "read": "Authenticated read access to the website",
         "write": "Authenticated write access to the website",

--- a/website/tosti/settings/development.py
+++ b/website/tosti/settings/development.py
@@ -24,7 +24,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/(?:api|user/oauth)/.*"
 
 # OAuth configuration
-OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] = ["http", "https"]
+OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] = ["http", "https", "nu.thalia"]
 
 # Email
 # https://docs.djangoproject.com/en/3.2/topics/email/


### PR DESCRIPTION
This way ThaliApp can get credentials using a custom redirect scheme, instead of using https redirects. It's not optimal security-wise, but the risk of some other app intercepting a redirect is small (at least small enough that we allow it on concrexit), and setting up (and testing with) https redirects reliably is a pain.