### PR TITLE
Changed pk to id for all serializers

### DIFF
--- a/website/associations/api/v1/serializers.py
+++ b/website/associations/api/v1/serializers.py
@@ -10,4 +10,4 @@ class AssociationSerializer(serializers.ModelSerializer):
         """Meta class."""
 
         model = models.Association
-        fields = ["pk", "name"]
+        fields = ["id", "name"]

--- a/website/thaliedje/api/v1/serializers.py
+++ b/website/thaliedje/api/v1/serializers.py
@@ -86,6 +86,7 @@ class PlayerSerializer(serializers.ModelSerializer):
         model = models.Player
         fields = [
             "id",
+            "slug",
             "display_name",
             "venue",
             "track",

--- a/website/venues/api/v1/serializers.py
+++ b/website/venues/api/v1/serializers.py
@@ -12,7 +12,7 @@ class VenueSerializer(serializers.ModelSerializer):
         """Meta class."""
 
         model = models.Venue
-        fields = ["pk", "name", "slug", "color_in_calendar", "can_be_reserved"]
+        fields = ["id", "name", "slug", "color_in_calendar", "can_be_reserved"]
 
 
 class ReservationSerializer(serializers.ModelSerializer):
@@ -26,4 +26,4 @@ class ReservationSerializer(serializers.ModelSerializer):
         """Meta class."""
 
         model = models.Reservation
-        fields = ["pk", "title", "user", "association", "start", "end", "venue", "comment"]
+        fields = ["id", "title", "user", "association", "start", "end", "venue", "comment"]


### PR DESCRIPTION
Small changes to the serializers of the API such that they all use the `id` field and the `PlayerSerializer` also returns the `slug`.

Closes #310 
Closes #309 