### PR TITLE
Added ManifestStaticFilesStorage to production.py

### DIFF
--- a/website/tosti/settings/production.py.example
+++ b/website/tosti/settings/production.py.example
@@ -69,6 +69,9 @@ SERVER_EMAIL = 'www-cantres@science.ru.nl'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
+# Add hashes to static files for cache resets.
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+
 STATIC_ROOT = BASE_DIR.parent / "static"
 STATIC_URL = "/static/"
 MEDIA_ROOT = BASE_DIR.parent.parent / "writable" / "media"


### PR DESCRIPTION
Added `ManifestStaticFilesStorage` to `STATICFILES_STORAGE` in `production.py.example` such that filenames contain a hash when running `collectstatic`. This way cache gets reset when a CSS or javascript file changes.

Closes #321 