### PR TITLE
Optimize API endpoints

### DIFF
--- a/website/orders/api/v1/views.py
+++ b/website/orders/api/v1/views.py
@@ -48,7 +48,7 @@ class OrderListCreateAPIView(ListCreateAPIView):
         django_filters.rest_framework.DjangoFilterBackend,
     ]
     filter_class = OrderFilter
-    queryset = Order.objects.all()
+    queryset = Order.objects.select_related("user", "product")
 
     def get_queryset(self):
         """Get the queryset."""
@@ -92,7 +92,7 @@ class OrderRetrieveDestroyAPIView(LoggedRetrieveDestroyAPIView):
         "DELETE": ["orders:manage"],
     }
 
-    queryset = Order.objects.all()
+    queryset = Order.objects.select_related("user", "product")
 
     def destroy(self, request, *args, **kwargs):
         """Destroy an order."""
@@ -145,7 +145,7 @@ class ShiftRetrieveUpdateAPIView(LoggedRetrieveUpdateAPIView):
     """API View to retrieve and update a shift."""
 
     serializer_class = ShiftSerializer
-    queryset = Shift.objects.all()
+    queryset = Shift.objects.prefetch_related("assignees")
     permission_classes = [IsAuthenticatedOrTokenHasScopeForMethod]
     required_scopes_for_method = {
         "GET": ["orders:order"],

--- a/website/venues/api/v1/views.py
+++ b/website/venues/api/v1/views.py
@@ -45,7 +45,9 @@ class ReservationListAPIView(ListAPIView):
     """
 
     serializer_class = ReservationSerializer
-    queryset = Reservation.objects.filter(accepted=True)
+    queryset = Reservation.objects.filter(accepted=True).select_related(
+        "venue", "user", "user__association", "association"
+    )
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend, SearchFilter)
     filter_class = ReservationFilter
     search_fields = ["title"]


### PR DESCRIPTION
This adds some simple select_related/prefetch_related optimizations.
In practice, it may be a good idea to replace some of these
`select_related`s with `prefetch_related`s in case of 'association' or
'product' because there may be e.g. many more orders than products,
so that avoiding duplicate database output outweighs avoinding the
computational cost of prefetch over select_related.