### PR TITLE
Add venue_name to ShiftSerializer

### DIFF
--- a/website/orders/api/v1/serializers.py
+++ b/website/orders/api/v1/serializers.py
@@ -100,10 +100,15 @@ class ShiftSerializer(serializers.ModelSerializer):
 
     assignees = UserSerializer(many=True)
     amount_of_orders = serializers.SerializerMethodField()
+    venue_name = serializers.SerializerMethodField()
 
     def get_amount_of_orders(self, instance):
         """Get the amount of orders in the shift."""
         return instance.orders.filter(type=Order.TYPE_ORDERED).count()
+
+    def get_venue_name(self, instance):
+        """Get the name of the venue."""
+        return instance.venue.venue.name
 
     def create(self, validated_data):
         """
@@ -134,6 +139,7 @@ class ShiftSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "venue",
+            "venue_name",
             "start",
             "end",
             "can_order",

--- a/website/orders/api/v1/views.py
+++ b/website/orders/api/v1/views.py
@@ -110,7 +110,7 @@ class ShiftListCreateAPIView(LoggedListCreateAPIView):
     """API View to list and create shifts."""
 
     serializer_class = ShiftSerializer
-    queryset = Shift.objects.all()
+    queryset = Shift.objects.select_related("venue__venue").prefetch_related("assignees")
     permission_classes = [IsAuthenticatedOrTokenHasScopeForMethod]
     required_scopes_for_method = {
         "GET": ["orders:order"],


### PR DESCRIPTION
This would be really nice to have. Of course inlining a full VenueSerializer (in place of the TostiVenue id) would also work, but it feels a bit overkill and is not really correct, unless we keep the nesting with a TostiVenue in place: `"venue": {venue: {"id": 0, "name": "zuid", ...}}` instead of `"venue": {"id": 0, "name": "zuid", ...}`. All 3 options are ugly, so I opted for the simplest slightly ugly option.