### PR TITLE
Fix some small API bugs

### DIFF
--- a/website/orders/api/v1/serializers.py
+++ b/website/orders/api/v1/serializers.py
@@ -9,9 +9,6 @@ from users.api.v1.serializers import UserSerializer
 class ProductSerializer(serializers.ModelSerializer):
     """Serializer for Product model."""
 
-    # Swagger UI does not know a DecimalField so we have to do it this way
-    current_price = serializers.SerializerMethodField()
-
     def to_internal_value(self, data):
         """Convert a single integer (primary key) to a Product."""
         if type(data) == int:
@@ -21,10 +18,6 @@ class ProductSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError("Product with id {} not found.".format(data))
         else:
             return super(ProductSerializer, self).to_internal_value(data)
-
-    def get_current_price(self, instance):
-        """Get the current price."""
-        return instance.current_price
 
     class Meta:
         """Meta class."""
@@ -41,6 +34,8 @@ class ProductSerializer(serializers.ModelSerializer):
             "max_allowed_per_shift",
             "barcode",
         ]
+
+        read_only_fields = ["current_price"]
 
 
 class OrderSerializer(serializers.ModelSerializer):

--- a/website/users/api/v1/urls.py
+++ b/website/users/api/v1/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from .views import MeRetrieveAPIView
 
 urlpatterns = [
-    path("me", MeRetrieveAPIView.as_view(), name="me"),
+    path("me/", MeRetrieveAPIView.as_view(), name="me"),
 ]


### PR DESCRIPTION
- `product.current_price` was rendered as float, not decimal (in contrast to all other prices)
- `/api/v1/users/me/` with trailing / gave 404.