### PR TITLE
Create a way to add spotify tracks via their context URI

### DIFF
--- a/website/thaliedje/templates/thaliedje/search.html
+++ b/website/thaliedje/templates/thaliedje/search.html
@@ -2,7 +2,10 @@
 
 <link rel="stylesheet" href="{% static 'thaliedje/css/search.css' %}"/>
 <div id="player-search-container-{{ player.id }}">
-    <input v-model="query" id="search" type="text" maxlength="100" placeholder="Search for something to play" class="container-fluid form-control mb-3"/>
+    <form @submit.self.prevent="tryUrl">
+        <input v-model="query" id="search" type="text" maxlength="100" placeholder="Search for something to play" class="container-fluid form-control mb-3"/>
+        <label style="font-size: 0.8em;" for="search">Tip: try pasting a share URL of a Spotify track{% if show_admin_columns %}, playlist or album{% endif %} and pressing RETURN, this will instantly add the track to the queue.</label>
+    </form>
     <div id="results" class="px-3 search-list">
         <div class="row">
             <div class="{% if show_admin_columns %}col-lg-4{% else %}col{% endif %}" v-if="tracks.length > 0 && query !== ''">
@@ -111,6 +114,33 @@
             }
         },
         methods: {
+            tryUrl() {
+                let urlToTry = null;
+                try {
+                    urlToTry = new URL(this.query);
+                } catch (e) {
+                    if (!(e instanceof TypeError)) {
+                        throw e;
+                    }
+                    return;
+                }
+                if (urlToTry.hostname === "open.spotify.com") {
+                    if (urlToTry.pathname.startsWith("/track/")) {
+                        const track_id = urlToTry.pathname.replace("/track/", "");
+                        this.add_to_queue(track_id);
+                    }
+                    {% if show_admin_columns %}
+                        else if (urlToTry.pathname.startsWith("/playlist/")) {
+                            const playlist_id = urlToTry.pathname.replace("/playlist/", "");
+                            this.start_with_context(`spotify:playlist:${playlist_id}`);
+                        }
+                        else if (urlToTry.pathname.startsWith("/album/")) {
+                            const album_id = urlToTry.pathname.replace("/album/", "");
+                            this.start_with_context(`spotify:album:${album_id}`);
+                        }
+                    {% endif %}
+                }
+            },
             add_to_queue(track_id) {
                 fetch(
                     "{% url "v1:player_add" player=player %}",


### PR DESCRIPTION
Create a way to add Spotify tracks, albums and playlists via their share link.

To test, do the following:

- Log in with an admin account and go to a player.
- Search for `https://open.spotify.com/album/1ZwkNGxlonmG4bjmLbV1Rr?si=9dTKb83mQRKNNlV1bHoWkg` and press RETURN.
- Observe that `Begin Again` by Ben Böhmer starts playing.
- Now search for `https://open.spotify.com/playlist/37i9dQZF1DWTvNyxOwkztu?si=90887a82d38b40a3` and press RETURN.
- Observe that `Chillout Lounge` starts playing.
- Now try to add a track by searching for `https://open.spotify.com/artist/5tDjiBYUsTqzd0RkTZxK7u?si=22341e2c41274e8f` and pressing RETURN.
- Observe that `Escalate` by Ben Böhmer is added to the queue.

Try the same with a non-admin account, only the track functionality should work.

Closes #354 