### PR TITLE
Change date of borrel reservation sync to start date of event

### DIFF
--- a/website/tantalus/services.py
+++ b/website/tantalus/services.py
@@ -287,7 +287,7 @@ def synchronize_borrelreservation_to_tantalus(borrel_reservation: BorrelReservat
     try:
         tantalus_client.register_transaction(
             tantalus_relation,
-            borrel_reservation.submitted_at,
+            borrel_reservation.start,
             description=borrel_reservation.title,
             sell=[
                 {"id": tantalus_product.tantalus_id, "amount": amount}

--- a/website/tantalus/tests/test_services.py
+++ b/website/tantalus/tests/test_services.py
@@ -84,7 +84,7 @@ class TantalusServicesTests(TestCase):
         services.synchronize_borrelreservation_to_tantalus(self.borrel_reservation)
         tantalus_client_mock.register_transaction.assert_called_with(
             self.tantalus_association,
-            self.borrel_reservation.submitted_at,
+            self.borrel_reservation.start,
             description=self.borrel_reservation.title,
             sell=[
                 {
@@ -163,7 +163,7 @@ class TantalusServicesTests(TestCase):
         services.synchronize_borrelreservation_to_tantalus(self.borrel_reservation)
         tantalus_client_mock.register_transaction.assert_called_with(
             self.tantalus_association,
-            self.borrel_reservation.submitted_at,
+            self.borrel_reservation.start,
             description=self.borrel_reservation.title,
             sell=[
                 {
@@ -210,7 +210,7 @@ class TantalusServicesTests(TestCase):
         services.synchronize_borrelreservation_to_tantalus(self.borrel_reservation)
         tantalus_client_mock.register_transaction.assert_called_with(
             self.tantalus_association,
-            self.borrel_reservation.submitted_at,
+            self.borrel_reservation.start,
             description=self.borrel_reservation.title,
             sell=[
                 {
@@ -246,7 +246,7 @@ class TantalusServicesTests(TestCase):
         services.synchronize_borrelreservation_to_tantalus(self.borrel_reservation)
         tantalus_client_mock.register_transaction.assert_called_with(
             self.tantalus_association,
-            self.borrel_reservation.submitted_at,
+            self.borrel_reservation.start,
             description=self.borrel_reservation.title,
             sell=[
                 {


### PR DESCRIPTION
Change the date of a borrel reservation to the start date of the event when synced to Tantalus.