### PR TITLE
Add products to shift export and time filters

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -203,6 +203,14 @@ python-versions = "*"
 django = ">=2.0"
 
 [[package]]
+name = "django-admin-rangefilter"
+version = "0.9.0"
+description = "django-admin-rangefilter app, add the filter by a custom date range on the admin UI."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "django-autocompletefilter"
 version = "0.0.8"
 description = "Django ModelAdmin list_filter with autocomplete widget."
@@ -356,7 +364,7 @@ python3-saml = "*"
 type = "git"
 url = "https://github.com/imsweb/django-saml-sp.git"
 reference = "main"
-resolved_reference = "16fb03171988dd34e51cd277be70e5e3a587b48e"
+resolved_reference = "6e1525b12d76209f5d92178b3a68c0b57d329b82"
 
 [[package]]
 name = "djangorestframework"
@@ -906,7 +914,7 @@ lxml = ">=3.8"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.10"
-content-hash = "5cdde5bf15dbe9489a4412996a14ac1758812c06a31b27375f316bdea1cb242c"
+content-hash = "47458be096534510148e0a370472f532739641c19115b20e3f15ae803f13b031"
 
 [metadata.files]
 asgiref = [
@@ -1145,6 +1153,10 @@ django = [
 django-admin-autocomplete-filter = [
     {file = "django-admin-autocomplete-filter-0.5.tar.gz", hash = "sha256:9d95a4407c3289e823c3486ddb200124c4ec8edf11064a0b8cb998d32c39530e"},
     {file = "django_admin_autocomplete_filter-0.5-py3-none-any.whl", hash = "sha256:44556b4b4d02c09a7ccdfc43e38c1e0f032741c6d484e9a6c542d7180b029418"},
+]
+django-admin-rangefilter = [
+    {file = "django-admin-rangefilter-0.9.0.tar.gz", hash = "sha256:e6aea6d6e9882b716beca7350a2a14db35c4cec204682b5a94dfd8110628e8ac"},
+    {file = "django_admin_rangefilter-0.9.0-py2.py3-none-any.whl", hash = "sha256:d028cea6a1ec8f8ac98c34cf79950c03641ab4942a5cd5b285ef35ccef0595b6"},
 ]
 django-autocompletefilter = [
     {file = "django-autocompletefilter-0.0.8.tar.gz", hash = "sha256:706dd00abdc189fb93f2907d29f7c60ced4b553a2e2d06fc77b5d1fc10761f0d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django-constance = {extras = ["database"], version = "^2.9.0"}
 html2text = "^2020.1.16"
 django-ical = "^1.8.3"
 fontawesomefree = "^6.1.1"
+django-admin-rangefilter = "^0.9.0"
 
 [tool.poetry.dev-dependencies]
 pydocstyle = "^5.0.2"

--- a/website/borrel/admin.py
+++ b/website/borrel/admin.py
@@ -3,6 +3,7 @@ from django.contrib.admin import EmptyFieldListFilter
 from django.db import models
 from django.forms import Textarea
 from import_export.admin import ExportMixin, ImportExportModelAdmin
+from rangefilter.filters import DateRangeFilter
 
 from .models import (
     BasicBorrelBrevet,
@@ -146,7 +147,7 @@ class BorrelReservationAdmin(ExportMixin, admin.ModelAdmin):
         "accepted",
         ("submitted_at", EmptyFieldListFilter),
         "association",
-        "start",
+        ("start", DateRangeFilter),
     )
 
     def submitted(self, obj):

--- a/website/orders/admin.py
+++ b/website/orders/admin.py
@@ -9,9 +9,11 @@ from django.db.models import Q
 from django.forms import CheckboxSelectMultiple
 from django.urls import reverse
 from guardian.admin import GuardedModelAdmin
-from import_export.admin import ImportExportModelAdmin
+from import_export.admin import ImportExportModelAdmin, ExportMixin
+from rangefilter.filters import DateRangeFilter
 
 from orders.models import Product, Order, Shift, OrderVenue, OrderBlacklistedUser
+from orders.resources import ShiftResource
 
 from users.models import User
 
@@ -123,10 +125,11 @@ class ShiftAdminForm(forms.ModelForm):
 
 
 @admin.register(Shift)
-class ShiftAdmin(GuardedModelAdmin, ImportExportModelAdmin):
+class ShiftAdmin(ExportMixin, GuardedModelAdmin):
     """Custom admin for shifts."""
 
     form = ShiftAdminForm
+    resource_class = ShiftResource
 
     list_display = [
         "date",
@@ -139,7 +142,7 @@ class ShiftAdmin(GuardedModelAdmin, ImportExportModelAdmin):
         "finalized",
     ]
 
-    list_filter = ["venue", "can_order", "finalized"]
+    list_filter = ["venue", "can_order", "finalized", ("start", DateRangeFilter)]
     inlines = [OrderInline]
 
     search_fields = ["start", "venue__venue__name"]

--- a/website/orders/resources.py
+++ b/website/orders/resources.py
@@ -1,0 +1,68 @@
+from import_export import resources
+from import_export.fields import Field
+
+from orders import models
+
+
+class ShiftResource(resources.ModelResource):
+    """Shift Resource."""
+
+    def __init__(self):
+        """Initialize by creating a field for each product."""
+        super(ShiftResource, self).__init__()
+        self.added_product_fields = dict()
+
+    def before_export(self, queryset, *args, **kwargs):
+        """Initialize by creating a field for each product."""
+        product_names = models.Order.objects.filter(shift__in=queryset).values_list("product__name", "product__id")
+        for product_name, product_id in product_names:
+            attribute_id_ordered = f"__product_{product_name}_ordered"
+            self.fields[attribute_id_ordered] = Field(
+                column_name=f"{product_name}", attribute=attribute_id_ordered, readonly=True
+            )
+            self.added_product_fields[attribute_id_ordered] = product_id
+
+    def export_product_field(self, field, obj):
+        """Export the custom product fields."""
+        try:
+            amount_of_orders = models.Order.objects.filter(
+                shift=obj, product_id=self.added_product_fields[field.attribute]
+            ).count()
+            return amount_of_orders
+        except models.Order.DoesNotExist:
+            pass
+        return None
+
+    def export_field(self, field, obj):
+        """Check for added product field before exporting."""
+        if field.attribute in self.added_product_fields.keys():
+            return self.export_product_field(field, obj)
+        else:
+            return super(ShiftResource, self).export_field(field, obj)
+
+    class Meta:
+        """Meta class."""
+
+        model = models.Shift
+        fields = [
+            "id",
+            "venue",
+            "start",
+            "end",
+            "can_order",
+            "finalized",
+            "max_orders_per_user",
+            "max_orders_total",
+            "assignees",
+        ]
+        export_order = [
+            "id",
+            "venue",
+            "start",
+            "end",
+            "can_order",
+            "finalized",
+            "max_orders_per_user",
+            "max_orders_total",
+            "assignees",
+        ]

--- a/website/tosti/settings/base.py
+++ b/website/tosti/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     "guardian",
     'rest_framework',
     'django_filters',
+    'rangefilter',
     "users",
     "venues",
     "associations",

--- a/website/venues/admin.py
+++ b/website/venues/admin.py
@@ -2,6 +2,7 @@ from admin_auto_filters.filters import AutocompleteFilter
 from django.contrib import admin, messages
 from django import forms
 from django.db.models import Q
+from rangefilter.filters import DateRangeFilter
 
 from venues.models import Venue, Reservation
 
@@ -46,13 +47,7 @@ class ReservationAdmin(admin.ModelAdmin):
     """Custom admin for reservations."""
 
     list_display = ["title", "venue", "association", "start", "end", "user", "accepted"]
-    list_filter = [
-        "venue",
-        "association",
-        "start",
-        "accepted",
-        "start",
-    ]
+    list_filter = ["venue", "association", ("start", DateRangeFilter), "accepted"]
     search_fields = ["title"]
     autocomplete_fields = ["user"]
     # date_hierarchy = "start"


### PR DESCRIPTION
This PR does two things:

- It adds products to exports for shifts (so the amount of products ordered).
- It adds a better time filter to the admin list filters that have one.

To test, first create some shifts and order some products. Then go to the shift admin dashboard and click export at the top right. Verify whether the products are exported correctly.

Closes #390 