### PR TITLE
Rewrite views to use visibility change

### DIFF
--- a/website/orders/templates/orders/order_admin_list.html
+++ b/website/orders/templates/orders/order_admin_list.html
@@ -160,6 +160,18 @@
                 .then(json => {
                     this.products = json;
                 });
+            add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refreshed_order_data);
+            add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refreshed_shift_data);
+        },
+        watch: {
+            shift: {
+                handler(newValue, oldValue) {
+                    if (newValue.finalized === true) {
+                        remove_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refreshed_order_data);
+                        remove_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refreshed_shift_data);
+                    }
+                }
+            }
         },
         computed: {
             user_orders: function() {
@@ -354,10 +366,12 @@
             }
         }
     });
-    add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", function (data) {
-        orders_vue_{{ shift.id }}.orders = data
-    });
-    add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", function (data) {
-        orders_vue_{{ shift.id }}.shift = data
-    });
+
+    function process_refreshed_order_data(data) {
+        orders_vue_{{ shift.id }}.orders = data;
+    }
+
+    function process_refreshed_shift_data(data) {
+        orders_vue_{{ shift.id }}.shift = data;
+    }
 </script>

--- a/website/orders/templates/orders/order_list.html
+++ b/website/orders/templates/orders/order_list.html
@@ -102,6 +102,16 @@
             user: null,
             addingOrder: false,
         },
+        watch: {
+            shift: {
+                handler(newValue, oldValue) {
+                    if (newValue.finalized === true) {
+                        remove_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refreshed_order_data);
+                        remove_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_shift_data);
+                    }
+                }
+            }
+        },
         created() {
              fetch('{% url "v1:me" %}')
                 .then(response => response.json())
@@ -109,6 +119,8 @@
                     this.user = json;
                 });
             this.refresh();
+            add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refreshed_order_data);
+            add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_shift_data);
         },
         computed: {
              user_orders: function() {
@@ -194,11 +206,13 @@
             },
         }
     });
-    add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", function (data) {
+
+    function process_refreshed_order_data(data) {
         data = data.filter(order => order.type === 0);
-        orders_vue_{{ shift.id }}.orders = data
-    });
-    add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", function (data) {
-        orders_vue_{{ shift.id }}.shift = data
-    });
+        orders_vue_{{ shift.id }}.orders = data;
+    }
+
+    function process_shift_data(data) {
+        orders_vue_{{ shift.id }}.shift = data;
+    }
 </script>

--- a/website/orders/templates/orders/shift_admin_footer.html
+++ b/website/orders/templates/orders/shift_admin_footer.html
@@ -112,6 +112,18 @@
                 .then(json => {
                     this.shift = json;
                 });
+            add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refresh_order_footer_data);
+            add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refresh_shift_footer_data);
+        },
+        watch: {
+            shift: {
+                handler(newValue, oldValue) {
+                    if (newValue.finalized === true) {
+                        remove_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", process_refresh_order_footer_data);
+                        remove_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refresh_shift_footer_data);
+                    }
+                }
+            }
         },
         methods: {
             adjust_can_order(can_order) {
@@ -215,10 +227,12 @@
             }
         }
     });
-    add_refresh_url("{% url "v1:orders_listcreate" shift=shift %}", function (data) {
-        admin_footer_vue_{{ shift.id }}.orders = data
-    });
-    add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", function (data) {
-        admin_footer_vue_{{ shift.id }}.shift = data
-    });
+
+    function process_refresh_order_footer_data(data) {
+        admin_footer_vue_{{ shift.id }}.orders = data;
+    }
+
+    function process_refresh_shift_footer_data(data) {
+        admin_footer_vue_{{ shift.id }}.shift = data;
+    }
 </script>

--- a/website/orders/templates/orders/shift_admin_scanner.html
+++ b/website/orders/templates/orders/shift_admin_scanner.html
@@ -65,6 +65,13 @@
                         this.typing_timer = setTimeout(this.search, 200);
                     }
                 }
+            },
+            shift: {
+                handler(newValue, oldValue) {
+                    if (newValue.finalized === true) {
+                        remove_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refresh_scanner_data);
+                    }
+                }
             }
         },
         created() {
@@ -73,6 +80,7 @@
                 .then(json => {
                     this.shift = json;
                 });
+            add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", process_refresh_scanner_data);
         },
         mounted() {
             //call function on modal shown
@@ -150,7 +158,8 @@
             }
         }
     });
-    add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", function(data) {
-        scanner_vue.shift = data
-    });
+
+    function process_refresh_scanner_data(data) {
+        scanner_vue.shift = data;
+    }
 </script>

--- a/website/orders/templates/orders/shift_header.html
+++ b/website/orders/templates/orders/shift_header.html
@@ -50,7 +50,20 @@
                 .then(json => {
                     this.shift = json;
                 });
+            add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", refresh_shift_header_data);
+        },
+        watch: {
+            shift: {
+                handler(newValue, oldValue) {
+                    if (newValue.finalized === true) {
+                        remove_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", refresh_shift_header_data);
+                    }
+                }
             }
-        });
-    add_refresh_url("{% url "v1:shift_retrieveupdate" pk=shift.id %}", function(data) {shift_header_{{ shift.id }}_vue.shift = data});
+        },
+    });
+
+    function refresh_shift_header_data(data) {
+        shift_header_{{ shift.id }}_vue.shift = data;
+    }
 </script>

--- a/website/thaliedje/templates/thaliedje/admin/authorize_succeeded.html
+++ b/website/thaliedje/templates/thaliedje/admin/authorize_succeeded.html
@@ -16,6 +16,6 @@
 {% block content %}
     <h1>Spotify Authorization</h1>
     <p>Authorization finished successfully! You have now added authorization for the account <strong>{{ original.get_display_name }}</strong>.</p>
-    <p>Now make sure to complete configuration by selecting a playback device and optionally a venue in <a href="{% url "admin:thaliedje_player_change" original.id %}">here</a>.</p>
+    <p>Now make sure to complete configuration by selecting a playback device and optionally a venue in <a href="{% url "admin:thaliedje_spotifyplayer_change" original.id %}">here</a>.</p>
     <p>Also, don't forget to grant the correct permissions to users and groups for this player!</p>
 {% endblock %}

--- a/website/thaliedje/templates/thaliedje/player.html
+++ b/website/thaliedje/templates/thaliedje/player.html
@@ -113,24 +113,32 @@
             track_progress_ms: 0,
             track_progress_percentage: 0,
             track_ms_left: 0,
+            lastRefresh: null,
         },
         created() {
             this.refresh();
-            this.recalculate_progress_interval = setInterval(() => {
-                this.updateTrackProgress();
-            }, 100);
-        },
-        mounted() {
-            this.refresh_timer = setTimeout(this.refresh, 2000);
-            this.recalculate_progress_interval = setInterval(() => {
-                this.updateTrackProgress();
-            }, 100);
+            this.recalculate_progress_interval = setInterval(this.updateTrackProgress, 100);
+            document.addEventListener("visibilitychange", this.visibilityChange);
         },
         unmounted() {
-            clearTimeout(this.refresh_timer);
-            clearInterval(this.recalculate_progress_interval);
+            document.removeEventListener("visibilitychange", this.visibilityChange);
         },
         methods: {
+            visibilityChange(event) {
+                if (event.target.hidden) {
+                    clearTimeout(this.refresh_timer);
+                    clearInterval(this.recalculate_progress_interval);
+                } else {
+                    clearTimeout(this.refresh_timer);
+                    clearInterval(this.recalculate_progress_interval);
+                    this.recalculate_progress_interval = setInterval(this.updateTrackProgress, 100);
+                    if (this.lastRefresh === null || (new Date()).getTime() - this.lastRefresh > 5000) {
+                        this.refresh();
+                    } else {
+                        this.refresh_timer = setTimeout(this.refresh, 5000);
+                    }
+                }
+            },
             updateTrackProgress() {
                 if (this.player_data.is_playing === false) return
 
@@ -413,6 +421,7 @@
                 }).catch(error => {
                     console.log(`An error occurred while refreshing player {{ player.id }}. Error: ${error}`)
                 }).finally(() => {
+                    this.lastRefresh = (new Date()).getTime();
                     this.refresh_timer = setTimeout(this.refresh, 5000);
                 });
             }

--- a/website/thaliedje/templates/thaliedje/player.html
+++ b/website/thaliedje/templates/thaliedje/player.html
@@ -109,15 +109,26 @@
             doing_call: false,
             set_volume_index: 0,
             refresh_timer: null,
+            recalculate_progress_interval: null,
             track_progress_ms: 0,
             track_progress_percentage: 0,
             track_ms_left: 0,
         },
         created() {
             this.refresh();
-            setInterval(() => {
+            this.recalculate_progress_interval = setInterval(() => {
                 this.updateTrackProgress();
             }, 100);
+        },
+        mounted() {
+            this.refresh_timer = setTimeout(this.refresh, 2000);
+            this.recalculate_progress_interval = setInterval(() => {
+                this.updateTrackProgress();
+            }, 100);
+        },
+        unmounted() {
+            clearTimeout(this.refresh_timer);
+            clearInterval(this.recalculate_progress_interval);
         },
         methods: {
             updateTrackProgress() {

--- a/website/thaliedje/templates/thaliedje/queue.html
+++ b/website/thaliedje/templates/thaliedje/queue.html
@@ -36,17 +36,41 @@
         el: '#queue-container-{{ player.id }}',
         delimiters: ['<%', '%>'],
         data: {
-            queue: []
+            queue: [],
+            refreshTimer: null,
+            lastRefresh: null,
         },
         created() {
-            fetch('{% url "v1:player_queue" player=player %}')
-            .then(response => response.json())
-            .then(json => {
-                this.queue = json;
-            });
+            this.refresh_player_queue();
+            document.addEventListener("visibilitychange", this.visibilityChange);
+        },
+        unmounted() {
+            document.removeEventListener("visibilitychange", this.visibilityChange);
+        },
+        methods: {
+            refresh_player_queue() {
+                fetch('{% url "v1:player_queue" player=player %}')
+                    .then(response => response.json())
+                    .then(json => {
+                        this.queue = json;
+                    })
+                    .finally(() => {
+                        this.lastRefresh = (new Date()).getTime();
+                        this.refreshTimer = setTimeout(this.refresh_player_queue, 5000);
+                    });
+            },
+            visibilityChange(event) {
+                if (event.target.hidden) {
+                    clearTimeout(this.refreshTimer);
+                } else {
+                    clearTimeout(this.refreshTimer);
+                    if (this.lastRefresh === null || (new Date()).getTime() - this.lastRefresh > 5000) {
+                        this.refresh_player_queue();
+                    } else {
+                        this.refreshTimer = setTimeout(this.refresh_player_queue, 5000);
+                    }
+                }
+            },
         }
-    });
-    add_refresh_url("{% url 'v1:player_queue' player=player %}", function (data) {
-        player_{{ player.id }}_queue_vue.queue = data
     });
 </script>

--- a/website/thaliedje/templates/thaliedje/requests.html
+++ b/website/thaliedje/templates/thaliedje/requests.html
@@ -38,25 +38,45 @@
         el: '#requests-container-{{ player.id }}',
         delimiters: ['<%', '%>'],
         data: {
-            requests: []
+            requests: [],
+            refreshTimer: null,
+            lastRefresh: null,
         },
         created() {
-            fetch('{% url "v1:player_requests" player=player %}')
-            .then(response => response.json())
-            .then(json => json.results)
-            .then(json => {
-                json.forEach(track => {
-                    const date = new Date(track.added);
-                    track.added = `${date.toLocaleDateString()}, ${date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}`;
-                });
-                this.requests = json;
-            });
+            this.refresh_player_requests();
+            document.addEventListener("visibilitychange", this.visibilityChange);
+        },
+        unmounted() {
+            document.removeEventListener("visibilitychange", this.visibilityChange);
+        },
+        methods: {
+            refresh_player_requests() {
+                fetch('{% url "v1:player_requests" player=player %}')
+                    .then(response => response.json())
+                    .then(json => json.results)
+                    .then(json => {
+                        json.forEach(track => {
+                            const date = new Date(track.added);
+                            track.added = `${date.toLocaleDateString()}, ${date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}`;
+                        });
+                        this.requests = json;
+                    }).finally(() => {
+                        this.lastRefresh = (new Date()).getTime();
+                        this.refreshTimer = setTimeout(this.refresh_player_requests, 5000);
+                    });
+            },
+            visibilityChange(event) {
+                if (event.target.hidden) {
+                    clearTimeout(this.refreshTimer);
+                } else {
+                    clearTimeout(this.refreshTimer);
+                    if (this.lastRefresh === null || (new Date()).getTime() - this.lastRefresh > 5000) {
+                        this.refresh_player_requests();
+                    } else {
+                        this.refreshTimer = setTimeout(this.refresh_player_requests, 5000);
+                    }
+                }
+            },
         }
-    });
-    add_refresh_url("{% url 'v1:player_requests' player=player %}", function (data) {
-        data.results.forEach(track => {
-            const date = new Date(track.added);track.added = `${date.toLocaleDateString()}, ${date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}`;
-        });
-        player_{{ player.id }}_requests_vue.requests = data.results
     });
 </script>

--- a/website/tosti/static/tosti/js/base.js
+++ b/website/tosti/static/tosti/js/base.js
@@ -75,6 +75,18 @@ function add_refresh_url(url, assigner_func) {
     }
 }
 
+function remove_refresh_url(url, assigner_func) {
+    if (refresh_list[url]) {
+        const index = refresh_list[url].indexOf(assigner_func);
+        if (index >= 0) {
+            refresh_list[url].splice(index, 1);
+            if (refresh_list[url].length === 0) {
+                delete refresh_list[url];
+            }
+        }
+    }
+}
+
 function update_refresh_list() {
     clearTimeout(update_timer);
     Promise.all(Object.entries(refresh_list).map(([key, value]) => {

--- a/website/tosti/static/tosti/js/base.js
+++ b/website/tosti/static/tosti/js/base.js
@@ -1,7 +1,7 @@
 
 let update_timer = null;
-let update_list = [];
 let refresh_list = {};
+let lastRefresh = null;
 
 async function show_error_from_api(data) {
     if (data) {
@@ -77,8 +77,8 @@ function add_refresh_url(url, assigner_func) {
 
 function update_refresh_list() {
     clearTimeout(update_timer);
-    for (const [key, value] of Object.entries(refresh_list)) {
-        fetch(
+    Promise.all(Object.entries(refresh_list).map(([key, value]) => {
+        return fetch(
             key,
             {
                 headers: {
@@ -102,8 +102,10 @@ function update_refresh_list() {
         }).catch(error => {
             console.log(`An error occurred while refreshing ${key}. Error: ${error}`)
         });
-    }
-    update_timer = setTimeout(update_refresh_list, 5000);
+    })).finally(() => {
+        lastRefresh = (new Date()).getTime();
+        update_timer = setTimeout(update_refresh_list, 5000);
+    });
 }
 
 function get_csrf_token() {
@@ -121,4 +123,18 @@ function get_csrf_token() {
     }
 }
 
+function visibilityChange(event) {
+    if (event.target.hidden) {
+        clearTimeout(update_timer);
+    } else {
+        clearTimeout(update_timer);
+        if (lastRefresh === null || (new Date()).getTime() - lastRefresh > 5000) {
+            update_refresh_list();
+        } else {
+            update_timer = setTimeout(update_refresh_list, 5000);
+        }
+    }
+}
+
 update_refresh_list();
+document.addEventListener("visibilitychange", visibilityChange);


### PR DESCRIPTION
This PR changes two things:

- The views now support the `visibilitychange` event which disables refreshes when the tab is not in view.
- The order admin and order view now stop refreshing when the shift has finalized.

Closes #403 