### PR TITLE
Allow admin for shift without joining it

### DIFF
--- a/website/announcements/tests/test_services.py
+++ b/website/announcements/tests/test_services.py
@@ -6,22 +6,22 @@ from announcements.services import sanitize_closed_announcements, validate_close
 
 class OrderServicesTests(TestCase):
     def test_sanitize_closed_announcements_none(self):
-        self.assertEquals([], sanitize_closed_announcements(None))
+        self.assertEqual([], sanitize_closed_announcements(None))
 
     def test_sanitize_closed_announcements_non_string(self):
-        self.assertEquals([], sanitize_closed_announcements(5))
+        self.assertEqual([], sanitize_closed_announcements(5))
 
     def test_sanitize_closed_announcements_non_json(self):
-        self.assertEquals([], sanitize_closed_announcements("this,is,not,json"))
+        self.assertEqual([], sanitize_closed_announcements("this,is,not,json"))
 
     def test_sanitize_closed_announcements_non_list(self):
-        self.assertEquals([], sanitize_closed_announcements("{}"))
+        self.assertEqual([], sanitize_closed_announcements("{}"))
 
     def test_sanitize_closed_announcements_list_of_ints(self):
-        self.assertEquals([1, 8, 4], sanitize_closed_announcements("[1, 8, 4]"))
+        self.assertEqual([1, 8, 4], sanitize_closed_announcements("[1, 8, 4]"))
 
     def test_sanitize_closed_announcements_list_of_different_types(self):
-        self.assertEquals(
+        self.assertEqual(
             [1, 8, 4], sanitize_closed_announcements('[1, "bla", 8, 4, 123.4, {"a": "b"}, ["This is also a list"]]')
         )
 

--- a/website/orders/services.py
+++ b/website/orders/services.py
@@ -13,11 +13,6 @@ from users.models import User
 logger = logging.getLogger(__name__)
 
 
-def user_can_manage_shift(user, shift):
-    """Return if the user can manage this shift."""
-    return user_can_manage_shifts_in_venue(user, shift.venue) and user in shift.assignees.all()
-
-
 def user_can_manage_shifts_in_venue(user, venue):
     """Return if the user can manage this shift."""
     return user.has_perm("orders.can_manage_shift_in_venue", venue)

--- a/website/orders/templates/orders/join_shift.html
+++ b/website/orders/templates/orders/join_shift.html
@@ -9,12 +9,12 @@
     <div class="container my-5">
         <div class="row justify-content-center">
             <form method="post" class="col-8 col-sm-offset-2">
-                <h1>Join {{ shift.venue.venue.name }} shift #{{ shift.pk }}</h1>
+                <h1>Join/Manage {{ shift.venue.venue.name }} shift #{{ shift.pk }}</h1>
                 {% bootstrap_messages %}
                 <p>Do you want to join this shift as a baker (add yourself to the baker list)?</p>
                 {% csrf_token %}
-                {% bootstrap_button button_type="submit" name="confirm" value="Yes" content="Yes" button_class="btn-success" extra_classes="mt-4 w-100" %}
-                {% bootstrap_button button_type="submit" name="confirm" value="No" content="No" button_class="btn-danger" extra_classes="mt-4 w-100" %}
+                {% bootstrap_button button_type="submit" name="confirm" value="Yes" content="Yes, add me to the baker list" button_class="btn-success" extra_classes="mt-4 w-100" %}
+                {% bootstrap_button button_type="submit" name="confirm" value="No" content="No, I only want to manage" button_class="btn-danger" extra_classes="mt-4 w-100" %}
             </form>
         </div>
     </div>

--- a/website/orders/templates/orders/shift_overview.html
+++ b/website/orders/templates/orders/shift_overview.html
@@ -9,7 +9,7 @@
 
 {% block footer %}
     {% if can_manage_shift and user not in shift.assignees.all %}
-        <footer class="navbar navbar-expand-md mt-auto footer" style="z-index: unset;">
+        <footer class="page-footer navbar navbar-expand-md mt-auto footer" style="z-index: unset;">
             <div class="container text-center">
                 <div class="row flex-grow-1">
                     <div class="col">

--- a/website/orders/tests/test_views.py
+++ b/website/orders/tests/test_views.py
@@ -136,8 +136,13 @@ class OrderViewTests(TestCase):
         self.assertTrue(self.normal_user.has_perm("orders.can_manage_shift_in_venue", self.order_venue_1))
         self.assertFalse(self.normal_user in self.shift.assignees.all())
         response = self.client.post(reverse("orders:shift_join", kwargs={"shift": self.shift}), data={"confirm": "No"})
-        self.assertRedirects(response, reverse("index"))
+        self.assertRedirects(response, reverse("orders:shift_admin", kwargs={"shift": self.shift}))
         self.assertFalse(self.normal_user in self.shift.assignees.all())
+        self.assertTrue(
+            str(response.cookies.get(f"TOSTI_ASKED_JOIN_SHIFT_{self.shift.id}", None)).startswith(
+                f"Set-Cookie: TOSTI_ASKED_JOIN_SHIFT_{self.shift.id}=true;"
+            )
+        )
 
     def test_join_shift_view_post_no_data(self):
         self.assertTrue(self.client.login(username=self.normal_user.username, password="temporary"))
@@ -167,4 +172,4 @@ class OrderViewTests(TestCase):
         self.assertTrue(self.client.login(username=self.normal_user.username, password="temporary"))
         self.assertFalse(self.normal_user.has_perm("orders.can_manage_shift_in_venue", self.order_venue_1))
         response = self.client.get(reverse("orders:shift_admin", kwargs={"shift": self.shift}))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)

--- a/website/tosti/templates/tosti/venue_card.html
+++ b/website/tosti/templates/tosti/venue_card.html
@@ -28,7 +28,7 @@
                         <a href="{% url 'orders:shift_join' shift=venue_shift %}">
                             <div class="btn-ml btn-on my-2">
                                 <h4 class="my-0">
-                                    Join shift at {{ venue }}
+                                    Join/Manage shift at {{ venue }}
                                 </h4>
                             </div>
                         </a>

--- a/website/tosti/templatetags/venue_cards.py
+++ b/website/tosti/templatetags/venue_cards.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils import timezone
 
-from orders.services import user_can_manage_shifts_in_venue, user_can_manage_shift
+from orders.services import user_can_manage_shifts_in_venue
 from thaliedje.models import Player
 from orders.models import OrderVenue
 
@@ -23,7 +23,7 @@ def render_venue_card(context, shift=None, venue=None, show_player=True, show_ve
         or None,
         "request": context.get("request"),
         "admin": (venue and user_can_manage_shifts_in_venue(context["request"].user, venue))
-        or (shift and user_can_manage_shift(context["request"].user, shift)),
+        or (shift and user_can_manage_shifts_in_venue(context["request"].user, shift.venue)),
         "show_player": show_player and Player.get_player(venue.venue) is not None,
     }
 


### PR DESCRIPTION
Closes #533 

This PR alters the `JoinShiftView` to allow a user to go to the admin page without being in the assignees. The user will get redirected to the `JoinShiftView` once every 10 minutes if accessing the shift admin view without being in the assignees.