### PR TITLE
Enable uWSGI threading flags for Sentry compatibility

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ echo "🚀 Running migrations..."
 uv run manage.py migrate --noinput
 
 echo "🌐 Starting uWSGI server..."
-uv run uwsgi --http :80 --wsgi-file /app/tosti/wsgi.py --master --processes 4 --threads 2 --uid nobody --gid nogroup --disable-logging --static-map ${DJANGO_STATIC_URL}=${DJANGO_STATIC_ROOT} --static-map ${DJANGO_MEDIA_URL}=${DJANGO_MEDIA_ROOT}
+uv run uwsgi --http :80 --wsgi-file /app/tosti/wsgi.py --master --processes 4 --threads 2 --enable-threads --py-call-uwsgi-fork-hooks --uid nobody --gid nogroup --disable-logging --static-map ${DJANGO_STATIC_URL}=${DJANGO_STATIC_ROOT} --static-map ${DJANGO_MEDIA_URL}=${DJANGO_MEDIA_ROOT}


### PR DESCRIPTION
## Summary

Add `--enable-threads` and `--py-call-uwsgi-fork-hooks` to the uWSGI command in `entrypoint.sh`.

The Sentry SDK spawns a background thread to flush events asynchronously. Without `--enable-threads`, uWSGI runs in preforking mode without thread support, and the SDK emits a warning at startup:

> IMPORTANT: We detected the use of uWSGI in preforking mode without thread support. This might lead to crashing workers. Please run uWSGI with both "--enable-threads" and "--py-call-uwsgi-fork-hooks" for full support.

Under load this can cause workers to crash when the SDK tries to spin up its event-flushing thread. Adding both flags clears the warning and enables proper async error reporting.

## Test plan

- [ ] Verify the warning is gone from `docker compose logs web` after deploy.
- [ ] Confirm Sentry still receives events normally (trigger a test exception).