### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,86 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      django:
+        patterns:
+          - "django"
+          - "django-*"
+          - "djangorestframework"
+          - "drf-spectacular"
+        exclude-patterns:
+          # These ship their own release cadence and tend to lag behind
+          # Django's; bumping them in the same PR as Django itself usually
+          # fails on incompatible version constraints. Let them get their
+          # own PRs (via the saml group below or ungrouped).
+          - "djangosaml2"
+          - "django-constance"
+          - "django-ical"
+      saml:
+        patterns:
+          - "djangosaml2"
+          - "pysaml2"
+          - "pyopenssl"
+          - "cryptography"
+      dev-tools:
+        dependency-type: "development"
+      production-patches:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    labels:
+      - "dependencies"
+      - "docker"
+    # Postgres major bumps (17 → 18) change the on-disk format. CI can't
+    # catch this — it would only surface when the new database container
+    # tries to open the existing pg-data volume in production. Keep behind
+    # a human review for the pg_upgrade dance.
+    ignore:
+      - dependency-name: "postgres"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` covering four ecosystems on a weekly Monday cadence:

- **uv** — Python deps from `pyproject.toml` + `uv.lock`. Grouped so related bumps land together:
  - `django` — Django itself + most `django-*` plugins + DRF + drf-spectacular.
  - `saml` — `djangosaml2`, `pysaml2`, `pyopenssl`, `cryptography` (they release in lockstep).
  - `dev-tools` — everything in dev dependency-groups, one batched PR.
  - `production-patches` — patch-level bumps to runtime deps, batched separately from majors/minors so review noise stays low.
  - `djangosaml2`, `django-constance`, and `django-ical` are excluded from the `django` group because their release cadences lag Django itself; bumping them in the same PR tends to fail on incompatible constraints.
- **github-actions** — all action bumps grouped into one PR.
- **docker (/)** — base image of the production `Dockerfile`.
- **docker (/deploy)** — Caddy + Postgres images in the deploy stack. **Postgres major bumps are pinned** — those change the on-disk format and require a manual `pg_upgrade`, which CI cannot validate. Postgres minor/patch bumps still flow through.

The existing CI workflow (`test`, `lint`, `build-image`) already gates every PR, so nothing auto-merges without passing.

## Test plan

- [ ] Merge and wait for the next Monday window, or trigger from `Settings → Code security → Dependabot version updates → Check for updates`.
- [ ] First batch of PRs should appear within an hour.
- [ ] Confirm groups behave as configured (e.g. one combined `django` PR instead of one PR per plugin).