### PR TITLE
Use persistent DB connections to suppress transient DNS errors

### DIFF
--- a/website/tosti/settings/production.py
+++ b/website/tosti/settings/production.py
@@ -35,6 +35,14 @@ DATABASES = {
         "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
         "HOST": os.environ.get("POSTGRES_HOST"),
         "PORT": os.environ.get("POSTGRES_PORT"),
+        # Keep DB connections warm so we don't re-resolve `database` DNS
+        # and re-handshake Postgres on every request. Health-checks the
+        # cached connection cheaply before reuse, so a stale socket from
+        # a Postgres restart drops cleanly instead of erroring out — which
+        # was the root cause of the sporadic "could not translate host
+        # name 'database'" Sentry events.
+        "CONN_MAX_AGE": 600,
+        "CONN_HEALTH_CHECKS": True,
     }
 }
 


### PR DESCRIPTION
## Summary

Add `CONN_MAX_AGE=600` and `CONN_HEALTH_CHECKS=True` to the production `DATABASES` config.

## Why

Sporadic `OperationalError: could not translate host name "database" to address: Temporary failure in name resolution` events have been showing up in Sentry. Root cause is Docker's embedded DNS resolver hiccuping briefly during container restarts or under load.

With the default Django config (`CONN_MAX_AGE=0`), every request does a fresh DNS lookup + TCP handshake + Postgres auth — so the rare resolver miss becomes a 500 in the user's face and a Sentry event. With persistent connections, each uWSGI worker holds a single connection for up to 10 minutes. `CONN_HEALTH_CHECKS=True` cheaply validates that connection before reuse, so when Postgres restarts (e.g. during deploy) the cached socket fails the health check and Django reconnects once, rather than the request blowing up.

## Test plan

- [ ] Deploy and monitor Sentry for the `could not translate host name` error rate over a week. Expect a substantial drop.
- [ ] Confirm no regression in latency (persistent connections should improve it slightly, not hurt).