### PR TITLE
Wait for migrations before starting cron; widen web start_period

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -128,7 +128,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 60s
+      # web's entrypoint runs `migrate --noinput` before uWSGI starts; the
+      # health check counts that time against start_period. 60s is tight
+      # once the schema grows — give it a comfortable buffer so a cold
+      # deploy doesn't fail the check while migrate is still running.
+      start_period: 180s
 
   cron:
     image: *tosti-image
@@ -142,6 +146,12 @@ services:
       - outbound
     depends_on:
       database:
+        condition: service_healthy
+      # Wait for web's entrypoint to finish migrations before cron starts
+      # firing `runcrons`. Otherwise the first cron tick can race the
+      # migration and crash with "relation does not exist" — which lands
+      # in Sentry on every deploy.
+      web:
         condition: service_healthy
     volumes:
       - media:/media


### PR DESCRIPTION
## Summary

Two startup-ordering fixes that together stop Sentry from getting noise on every deploy.

### 1. Cron now depends on `web: service_healthy`, not just `database`

The cron container's entrypoint starts the system cron daemon, which fires `manage.py runcrons` every minute. Until now it only waited on the database — so on a deploy where a new migration adds a table or column that `runcrons` queries, the first cron tick races the still-running migrate in the web container and crashes with `relation "..." does not exist`.

Web is the only service that runs migrations, and it doesn't become healthy until uWSGI is serving `/ready` (i.e. after `migrate`). Using `web: service_healthy` as the cron gate makes that wait explicit.

### 2. Bump web's healthcheck `start_period` from 60s to 180s

Same root cause: web's entrypoint runs `migrate --noinput` before uWSGI. The healthcheck counts that time. 60s is tight once the schema grows; a cold deploy where migrate takes >60s flips web to unhealthy briefly, which now also blocks cron from starting (because of fix 1).

## Test plan

- [ ] Deploy with a migration on the diff and watch logs — cron should idle until `web` reports healthy, then start its minute ticks.
- [ ] Watch Sentry for the next few deploys: post-deploy `relation does not exist` errors should drop to zero.