### PR TITLE
Show commit SHA in footer

### DIFF
--- a/website/tosti/context_processors.py
+++ b/website/tosti/context_processors.py
@@ -1,11 +1,37 @@
+import os
+import subprocess
+from functools import lru_cache
+
 from constance import config
+from django.conf import settings
 
 from age.services import get_minimum_age
 
 
+@lru_cache(maxsize=1)
+def _get_commit_sha():
+    sha = os.environ.get("SENTRY_RELEASE")
+    if sha:
+        return sha
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=settings.BASE_DIR,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
 def footer_credits(request):
     """Get the footer credits as string."""
-    return {"FOOTER_CREDITS_TEXT": config.FOOTER_CREDITS_TEXT}
+    sha = _get_commit_sha()
+    return {
+        "FOOTER_CREDITS_TEXT": config.FOOTER_CREDITS_TEXT,
+        "COMMIT_SHA": sha,
+        "COMMIT_SHA_SHORT": sha[:7] if sha else None,
+    }
 
 
 def minimum_registered_age(request):

--- a/website/tosti/context_processors.py
+++ b/website/tosti/context_processors.py
@@ -20,7 +20,7 @@ def _get_commit_sha():
             stderr=subprocess.DEVNULL,
             text=True,
         ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    except subprocess.CalledProcessError, FileNotFoundError, OSError:
         return None
 
 

--- a/website/tosti/templates/tosti/base.html
+++ b/website/tosti/templates/tosti/base.html
@@ -311,6 +311,16 @@
             {% autoescape off %}
             {{ FOOTER_CREDITS_TEXT }}
             {% endautoescape %}
+            {% if COMMIT_SHA_SHORT %}
+                <br>
+                <small class="text-body-secondary">
+                    Version
+                    <a href="https://github.com/KiOui/TOSTI/commit/{{ COMMIT_SHA }}"
+                       class="text-body-secondary"
+                       target="_blank"
+                       rel="noopener noreferrer"><code>{{ COMMIT_SHA_SHORT }}</code></a>
+                </small>
+            {% endif %}
         </p>
     </div>
 </footer>


### PR DESCRIPTION
## Summary
- Footer now displays the short commit SHA of the running build, linked to the GitHub commit page
- Source order: `SENTRY_RELEASE` env var (already populated by the Dockerfile build arg in CI) with a `git rev-parse HEAD` fallback for local development
- Renders nothing if neither source is available, so dev environments without git stay clean

## Test plan
- [ ] Run locally and confirm the short SHA appears in the footer and links to the right commit on GitHub
- [ ] Verify the production Docker image picks up `SENTRY_RELEASE` and shows the build SHA
- [ ] Confirm the footer degrades gracefully when no SHA can be resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)