### PR TITLE
MCP follow-ups: branded consent screen, granular scopes, Marietje fix, serverInfo

### DIFF
--- a/website/orders/mcp.py
+++ b/website/orders/mcp.py
@@ -15,6 +15,22 @@ class OrderTools(MCPToolset):
     the API views and the MCP tools share one implementation.
     """
 
+    # See ``tosti.mcp.stamp_tool_annotations`` for what these do.
+    tool_annotations = {
+        "list_active_shifts": {
+            "readOnlyHint": True,
+            "openWorldHint": False,
+            "title": "List active shifts",
+        },
+        "place_order": {
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "openWorldHint": False,
+            "title": "Place an order",
+        },
+    }
+
     def list_active_shifts(self) -> list[dict]:
         """List currently active shifts where you can place an order.
 

--- a/website/thaliedje/mcp.py
+++ b/website/thaliedje/mcp.py
@@ -21,6 +21,28 @@ class ThaliedjeTools(MCPToolset):
     implementation.
     """
 
+    # See ``tosti.mcp.stamp_tool_annotations`` for what these do. ``search_tracks``
+    # is openWorld because it queries an external catalog (Spotify / Marietje).
+    tool_annotations = {
+        "get_player_state": {
+            "readOnlyHint": True,
+            "openWorldHint": False,
+            "title": "Get player state",
+        },
+        "search_tracks": {
+            "readOnlyHint": True,
+            "openWorldHint": True,
+            "title": "Search the music catalog",
+        },
+        "request_song": {
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "openWorldHint": False,
+            "title": "Request a song",
+        },
+    }
+
     def get_player_state(self, venue_slug: str) -> dict:
         """Return what the music player at the given venue is doing right now.
 

--- a/website/thaliedje/services.py
+++ b/website/thaliedje/services.py
@@ -28,9 +28,15 @@ def request_song(player, user, track_id):
 
 
 def get_player_for_venue(venue_slug: str) -> Player | None:
-    """Return the ``Player`` configured for the given venue, or ``None``."""
+    """Return the concrete ``Player`` configured for the given venue, or ``None``.
+
+    Uses ``InheritanceManager.select_subclasses()`` so we get a fully-loaded
+    ``SpotifyPlayer`` or ``MarietjePlayer`` — the base ``Player.current_*``
+    properties raise ``NotImplementedError`` and the subclass-specific state
+    (auth, URL) only loads on the subclass.
+    """
     try:
-        return Player.objects.get(venue__slug=venue_slug)
+        return Player.objects.select_subclasses().get(venue__slug=venue_slug)
     except Player.DoesNotExist:
         return None
 

--- a/website/thaliedje/tests/test_mcp.py
+++ b/website/thaliedje/tests/test_mcp.py
@@ -29,6 +29,24 @@ class ThaliedjeToolsReadTests(TestCase):
         result = self.tools.get_player_state("does-not-exist")
         self.assertIn("error", result)
 
+    def test_get_player_state_returns_marietje_subclass_state(self):
+        """Regression: bare ``Player.objects.get`` returns the base class,
+        whose ``current_*`` properties raise ``NotImplementedError``.
+        ``get_player_for_venue`` must use ``select_subclasses()`` so the
+        MarietjePlayer-specific properties resolve.
+        """
+        venue = Venue.objects.first()
+        MarietjePlayer.objects.create(slug="marietje-noord", venue=venue)
+        with patch(
+            "thaliedje.models.MarietjePlayer._current_playback", return_value=None
+        ):
+            result = self.tools.get_player_state(venue.slug)
+        # No error key, and the keys we promise are present.
+        self.assertNotIn("error", result)
+        self.assertEqual(result["venue"], str(venue))
+        self.assertIn("is_playing", result)
+        self.assertIn("track", result)
+
 
 class ThaliedjeToolsRequestSongTests(TestCase):
     fixtures = ["venues.json"]
@@ -55,8 +73,9 @@ class ThaliedjeToolsRequestSongTests(TestCase):
 
         mock_service.assert_called_once()
         args, _ = mock_service.call_args
-        # Player.objects.get may return the base ``Player`` type even though
-        # we created a MarietjePlayer; compare by primary key.
+        # The service uses select_subclasses(), so we get a concrete
+        # MarietjePlayer back — not the base ``Player``.
+        self.assertIsInstance(args[0], MarietjePlayer)
         self.assertEqual(args[0].pk, player.pk)
         self.assertEqual(args[1], self.user)
         self.assertEqual(args[2], "track-id-42")

--- a/website/tosti/apps.py
+++ b/website/tosti/apps.py
@@ -10,6 +10,7 @@ class TostiConfig(AppConfig):
     def ready(self):
         """Register signals and decorate the global MCP server."""
         from tosti import signals  # noqa
+
         self._configure_mcp_server()
 
     @staticmethod

--- a/website/tosti/apps.py
+++ b/website/tosti/apps.py
@@ -8,8 +8,82 @@ class TostiConfig(AppConfig):
     name = "tosti"
 
     def ready(self):
-        """Register signals."""
+        """Register signals and decorate the global MCP server."""
         from tosti import signals  # noqa
+        self._configure_mcp_server()
+
+    @staticmethod
+    def _configure_mcp_server():
+        """Brand the MCP server and stamp per-tool annotations.
+
+        django_mcp_server constructs ``global_mcp_server`` at import time
+        with a hard-coded ``"django_mcp_server"`` name, no instructions
+        and no icons. We patch the lowlevel ``Server`` instance here in
+        ``ready()`` so the Django ORM and settings are guaranteed to be
+        available, and so all per-app ``MCPToolset`` subclasses are
+        already registered by the time we walk the tool list.
+
+        - ``name`` / ``website_url`` / ``icons`` populate the
+          ``serverInfo`` field in the ``initialize`` response, which
+          clients render in their connector UI.
+        - ``instructions`` is prose loaded into the agent's context so it
+          uses the tools correctly. The auto-published
+          ``get_server_instructions`` tool also returns this text.
+        - Per-tool annotations (readOnlyHint, destructiveHint, …) let
+          clients group tools into read/write sections and prompt the
+          user before destructive actions.
+
+        Icon URLs are absolute and point at static files directly —
+        sidestepping the ``/favicon.ico`` 301 redirect, which some MCP
+        clients follow unreliably.
+        """
+        from django.conf import settings
+        from django.templatetags.static import static
+        from mcp import types as mcp_types
+        from mcp_server import mcp_server as global_mcp_server
+
+        from tosti.mcp import SERVER_INSTRUCTIONS, stamp_tool_annotations
+
+        base = getattr(
+            settings, "TOSTI_CANONICAL_URL", "https://tosti.science.ru.nl"
+        ).rstrip("/")
+
+        def absolute(path: str) -> str:
+            return base + static(path)
+
+        lowlevel = global_mcp_server._mcp_server
+        lowlevel.name = "TOSTI"
+        lowlevel.website_url = base + "/"
+        lowlevel.instructions = SERVER_INSTRUCTIONS
+        lowlevel.icons = [
+            mcp_types.Icon(
+                src=absolute("tosti/favicon/favicon-32x32.png"),
+                mimeType="image/png",
+                sizes=["32x32"],
+            ),
+            mcp_types.Icon(
+                src=absolute("tosti/favicon/favicon-16x16.png"),
+                mimeType="image/png",
+                sizes=["16x16"],
+            ),
+            mcp_types.Icon(
+                src=absolute("tosti/favicon/android-chrome-192x192.png"),
+                mimeType="image/png",
+                sizes=["192x192"],
+            ),
+            mcp_types.Icon(
+                src=absolute("tosti/favicon/android-chrome-512x512.png"),
+                mimeType="image/png",
+                sizes=["512x512"],
+            ),
+            mcp_types.Icon(
+                src=absolute("tosti/favicon/apple-touch-icon.png"),
+                mimeType="image/png",
+                sizes=["180x180"],
+            ),
+        ]
+
+        stamp_tool_annotations()
 
     def menu_items(self, _):
         """Register menu items."""

--- a/website/tosti/forms.py
+++ b/website/tosti/forms.py
@@ -1,5 +1,7 @@
 from django import forms
+from oauth2_provider.forms import AllowForm
 from oauth2_provider.models import Application
+from oauth2_provider.scopes import get_scopes_backend
 
 
 class OAuthCredentialsForm(forms.ModelForm):
@@ -13,3 +15,66 @@ class OAuthCredentialsForm(forms.ModelForm):
             "name",
             "redirect_uris",
         ]
+
+
+class GranularAuthorizationForm(AllowForm):
+    """Consent form that lets the user pick which requested scopes to grant.
+
+    The upstream ``AllowForm.scope`` is a hidden CharField — whatever the
+    client asked for is granted wholesale. We override it with a
+    ``MultipleChoiceField`` whose options are the scopes the client
+    actually requested, and add a hidden ``requested_scope`` field that
+    round-trips the original request through the POST so we can still
+    validate the user's selection is a subset of what was asked for.
+
+    The cleaned ``scope`` value is the space-joined subset the user
+    ticked, which the upstream ``AuthorizationView.form_valid`` then
+    forwards to ``create_authorization_response`` as the granted scope.
+    """
+
+    # Round-trip the originally-requested scopes through the form so the
+    # POST handler knows what the legal choices were. Without this, a user
+    # could craft a POST that grants an arbitrary scope by ticking a
+    # checkbox the GET never offered.
+    requested_scope = forms.CharField(widget=forms.HiddenInput())
+    scope = forms.MultipleChoiceField(
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "form-check-input"}),
+        required=True,
+        error_messages={
+            "required": "Select at least one permission, or click Cancel to deny.",
+        },
+    )
+
+    def __init__(self, *args, **kwargs):
+        # ``initial`` arrives as a space-separated string (from
+        # AuthorizationView.get_initial); MultipleChoiceField wants a list
+        # of codes, so split it before super() runs.
+        initial = kwargs.get("initial", {}) or {}
+        if isinstance(initial.get("scope"), str):
+            initial = {
+                **initial,
+                "scope": initial["scope"].split(),
+                "requested_scope": initial["scope"],
+            }
+            kwargs["initial"] = initial
+        super().__init__(*args, **kwargs)
+
+        # The list of requested scopes comes from `initial["requested_scope"]`
+        # on GET and from POST `data["requested_scope"]` on POST. Either way,
+        # split it into codes and use as the choice set.
+        requested = ""
+        if self.is_bound:
+            requested = self.data.get("requested_scope", "")
+        if not requested:
+            requested = self.initial.get("requested_scope", "")
+
+        all_scopes = get_scopes_backend().get_all_scopes()
+        self.fields["scope"].choices = [
+            (code, all_scopes.get(code, code))
+            for code in requested.split()
+            if code in all_scopes
+        ]
+
+    def clean_scope(self):
+        """Return the granted scopes as a space-separated string."""
+        return " ".join(self.cleaned_data["scope"])

--- a/website/tosti/mcp.py
+++ b/website/tosti/mcp.py
@@ -5,6 +5,20 @@ Each app contributes its own ``mcp.py`` defining a subclass of
 ``mcp_server.MCPToolset``. The ``mcp_server`` package autodiscovers them at
 startup. Use ``require_scope`` here to gate write tools on an OAuth2 scope,
 mirroring DRF's ``IsAuthenticatedOrTokenHasScope``.
+
+To classify tools for the MCP UI (read-only vs destructive, etc.), set a
+``tool_annotations`` class attribute on the toolset:
+
+    class MyTools(MCPToolset):
+        tool_annotations = {
+            "list_things": {"readOnlyHint": True, "openWorldHint": False},
+            "create_thing": {"readOnlyHint": False, "destructiveHint": False},
+        }
+
+These are stamped onto the registered tools in ``TostiConfig.ready`` so
+they reach the client in the ``tools/list`` response. Clients (e.g. Claude
+Desktop) use them to group tools into "Read" and "Write" sections and to
+require user confirmation for destructive actions.
 """
 
 
@@ -20,3 +34,63 @@ def require_scope(request, scope: str) -> str | None:
     if not hasattr(token, "is_valid") or not token.is_valid([scope]):
         return f"This tool requires the '{scope}' OAuth2 scope."
     return None
+
+
+SERVER_INSTRUCTIONS = """\
+TOSTI is the order/reservation/music system for the Huygens-building \
+canteens at Radboud University. You're acting on behalf of an authenticated \
+TOSTI user; everything you do is attributed to them and uses their \
+permissions.
+
+Tool conventions:
+
+- Venues are identified by ``slug`` (e.g. ``noordkantine``, ``zuidkantine``). \
+Resolve unknown venue references with ``list_venues`` first; never invent \
+slugs.
+- Shifts are identified by their integer ``id``. List active shifts with \
+``list_active_shifts`` before placing an order; only shifts whose ``can_order`` \
+is true accept new orders.
+- Music tools target a specific venue's player. The same venue may be backed \
+by Spotify or Marietje; the protocol abstracts over both — you don't need to \
+care which.
+
+Safety rules:
+
+- Confirm with the user before invoking any tool that places an order, \
+requests a song, or creates a reservation. These actions cost money, time, \
+or social capital and are visible to other people.
+- If a tool returns ``{"error": ...}``, surface the error to the user \
+verbatim — do not retry with different arguments unless they explicitly ask.
+- If you need a permission the user has not granted (an OAuth scope), the \
+tool will return an error mentioning the scope. Ask the user to re-authorise \
+TOSTI with that scope; do not work around it.
+
+If a tool is not listed by ``tools/list``, it does not exist — do not \
+invent one.\
+"""
+
+
+def stamp_tool_annotations():
+    """Set MCP ``ToolAnnotations`` on every registered tool.
+
+    Walks the global server's tool manager, recovers the originating
+    ``MCPToolset`` class from ``tool.fn.class_``, and copies the matching
+    entry from the class's ``tool_annotations`` dict onto the tool. Tools
+    without an entry are left untouched (clients will treat them as
+    "other" / unclassified).
+
+    Called from ``TostiConfig.ready`` after Django's app registry is
+    ready, so the tools are guaranteed to be in the manager.
+    """
+    from mcp.types import ToolAnnotations
+    from mcp_server import mcp_server as global_mcp_server
+
+    for tool in global_mcp_server._tool_manager.list_tools():
+        caller = getattr(tool, "fn", None)
+        toolset_cls = getattr(caller, "class_", None)
+        if toolset_cls is None:
+            continue
+        annotations = getattr(toolset_cls, "tool_annotations", {}).get(tool.name)
+        if not annotations:
+            continue
+        tool.annotations = ToolAnnotations(**annotations)

--- a/website/tosti/oauth_discovery.py
+++ b/website/tosti/oauth_discovery.py
@@ -25,6 +25,9 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from oauth2_provider.models import Application
 from oauth2_provider.scopes import get_scopes_backend
+from oauth2_provider.views import AuthorizationView
+
+from tosti.forms import GranularAuthorizationForm
 
 # Per-IP registration cap: protects the Application table from a flood of
 # self-registered clients. Tuned generously for a normal MCP client doing one
@@ -247,3 +250,20 @@ class DynamicClientRegistrationView(View):
         if forwarded:
             return forwarded.split(",")[0].strip()
         return request.META.get("REMOTE_ADDR", "unknown")
+
+
+class GranularAuthorizationView(AuthorizationView):
+    """Consent screen that lets the user grant a subset of requested scopes.
+
+    Swaps the upstream all-or-nothing ``AllowForm`` (whose ``scope`` is a
+    hidden string) for ``GranularAuthorizationForm`` (one checkbox per
+    requested scope). RFC 6749 §3.3 explicitly allows the authorization
+    server to issue a narrower scope than requested, so this is a
+    conforming refinement.
+
+    Everything else (PKCE, ``code_challenge`` round-trip, the
+    ``approval_prompt=auto`` short-circuit, the ``state``/``nonce``
+    plumbing) is inherited unchanged from ``AuthorizationView``.
+    """
+
+    form_class = GranularAuthorizationForm

--- a/website/tosti/settings/base.py
+++ b/website/tosti/settings/base.py
@@ -6,6 +6,10 @@ from django.contrib import messages
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 INSTALLED_APPS = [
+    # ``mcp_server`` registers tools in its ``ready()``. ``tosti.ready()``
+    # stamps per-tool annotations on top of that registration, so it must
+    # run AFTER mcp_server — hence mcp_server is listed first.
+    "mcp_server",
     "tosti",
     "django.contrib.admin",
     "django.contrib.admindocs",
@@ -28,7 +32,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "django_filters",
     "drf_spectacular",
-    "mcp_server",
     "rangefilter",
     "announcements",
     "users",
@@ -171,6 +174,11 @@ SPECTACULAR_SETTINGS = {
 # MCP server (Model Context Protocol) — exposes a subset of the API as
 # LLM-callable tools. Auth piggybacks on the existing OAuth2 / session stack.
 DJANGO_MCP_ENDPOINT = "mcp"
+
+# Absolute base URL used to build MCP ``serverInfo`` icon URLs so they
+# resolve directly without going through the ``/favicon.ico`` redirect.
+# Overridden per environment in production.py / development.py.
+TOSTI_CANONICAL_URL = "https://tosti.science.ru.nl"
 # OAuth2 must come first so DRF returns a 401 with a Bearer ``WWW-Authenticate``
 # header for unauthenticated requests — the standard signal for OAuth-aware
 # clients (and what RFC 9728 + the MCP spec expect). SessionAuthentication

--- a/website/tosti/settings/development.py
+++ b/website/tosti/settings/development.py
@@ -26,6 +26,10 @@ CORS_URLS_REGEX = r"^/(?:api|user/oauth)/.*"
 # OAuth configuration
 OAUTH2_PROVIDER["ALLOWED_REDIRECT_URI_SCHEMES"] = ["http", "https", "nu.thalia"]
 
+# MCP serverInfo icons are built relative to this base — point at the local
+# dev server so a connector added in dev shows the right icons.
+TOSTI_CANONICAL_URL = "http://127.0.0.1:8000"
+
 # Email
 # https://docs.djangoproject.com/en/3.2/topics/email/
 

--- a/website/tosti/templates/oauth2_provider/authorize.html
+++ b/website/tosti/templates/oauth2_provider/authorize.html
@@ -26,12 +26,26 @@
                     {% endif %}
                 {% endfor %}
 
-                <h2 class="h4 mt-4">It will be able to:</h2>
-                <ul>
-                    {% for scope in scopes_descriptions %}
-                        <li>{{ scope }}</li>
+                <h2 class="h4 mt-4">Choose what to allow</h2>
+                <p class="text-muted">
+                    {{ application.name }} is asking for these permissions. Tick the ones you want to grant; untick anything you'd rather not allow. You can revisit this from the <a href="{% url 'users:account' %}?active=connected_apps">Connected apps</a> tab any time.
+                </p>
+                <div class="my-3">
+                    {% for checkbox in form.scope %}
+                        <div class="form-check mb-2">
+                            {{ checkbox.tag }}
+                            <label for="{{ checkbox.id_for_label }}" class="form-check-label">
+                                <strong><code>{{ checkbox.data.value }}</code></strong>
+                                &mdash; {{ checkbox.choice_label }}
+                            </label>
+                        </div>
                     {% endfor %}
-                </ul>
+                </div>
+                {% if form.scope.errors %}
+                    <div class="alert alert-warning">
+                        {{ form.scope.errors }}
+                    </div>
+                {% endif %}
 
                 {% if redirect_uri %}
                     <p class="text-muted">
@@ -39,9 +53,8 @@
                     </p>
                 {% endif %}
 
-                {% if form.errors or form.non_field_errors %}
+                {% if form.non_field_errors %}
                     <div class="alert alert-danger">
-                        {{ form.errors }}
                         {{ form.non_field_errors }}
                     </div>
                 {% endif %}

--- a/website/tosti/templates/oauth2_provider/authorize.html
+++ b/website/tosti/templates/oauth2_provider/authorize.html
@@ -1,0 +1,64 @@
+{% extends "tosti/base.html" %}
+{% load static %}
+
+{% block title %}
+    TOSTI: Authorise {{ application.name }}
+{% endblock %}
+
+{% block page %}
+    <div class="container mt-5 mb-5 prose">
+        {% if not error %}
+            <div class="text-center mb-4">
+                <h1>Authorise {{ application.name }}</h1>
+                <p class="lead tagline">{{ application.name }} would like to act on your behalf in TOSTI.</p>
+            </div>
+
+            <p>
+                Before approving, make sure you trust this application &mdash; it will be able to perform the actions listed below using your account. You can revoke access at any time from the <a href="{% url 'users:account' %}?active=connected_apps">Connected apps</a> tab of your account page.
+            </p>
+
+            <form id="authorizationForm" method="post">
+                {% csrf_token %}
+
+                {% for field in form %}
+                    {% if field.is_hidden %}
+                        {{ field }}
+                    {% endif %}
+                {% endfor %}
+
+                <h2 class="h4 mt-4">It will be able to:</h2>
+                <ul>
+                    {% for scope in scopes_descriptions %}
+                        <li>{{ scope }}</li>
+                    {% endfor %}
+                </ul>
+
+                {% if redirect_uri %}
+                    <p class="text-muted">
+                        After approving, you'll be sent back to <code>{{ redirect_uri }}</code>.
+                    </p>
+                {% endif %}
+
+                {% if form.errors or form.non_field_errors %}
+                    <div class="alert alert-danger">
+                        {{ form.errors }}
+                        {{ form.non_field_errors }}
+                    </div>
+                {% endif %}
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <button type="submit" class="btn btn-secondary">Cancel</button>
+                    <button type="submit" name="allow" value="Authorize" class="btn btn-primary">Authorise</button>
+                </div>
+            </form>
+        {% else %}
+            <div class="text-center mb-4">
+                <h1>Authorisation error</h1>
+            </div>
+            <div class="alert alert-danger">
+                <strong>{{ error.error }}</strong>
+                {% if error.description %}<br>{{ error.description }}{% endif %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/website/tosti/templates/tosti/mcp_tools.html
+++ b/website/tosti/templates/tosti/mcp_tools.html
@@ -28,7 +28,17 @@
 
             {% for tool in toolset.tools %}
                 <div class="mb-4">
-                    <h3 id="tool-{{ tool.name }}"><code>{{ tool.name }}</code></h3>
+                    <h3 id="tool-{{ tool.name }}">
+                        <code>{{ tool.name }}</code>
+                        {% if tool.kind == "read-only" %}
+                            <span class="badge bg-success">read-only</span>
+                        {% elif tool.kind == "write" %}
+                            <span class="badge bg-warning text-dark">write</span>
+                        {% elif tool.kind == "destructive" %}
+                            <span class="badge bg-danger">destructive</span>
+                        {% endif %}
+                    </h3>
+                    {% if tool.title %}<p class="text-muted mb-1">{{ tool.title }}</p>{% endif %}
                     {% if tool.description %}
                         <p>{{ tool.description|linebreaksbr }}</p>
                     {% endif %}

--- a/website/tosti/tests/test_mcp.py
+++ b/website/tosti/tests/test_mcp.py
@@ -148,9 +148,7 @@ class AuthorizeConsentScreenTests(TestCase):
         response = self.client.get(self._authorize_url())
         # The csp_update decorator stamps the response so the CSP middleware
         # merges in the override.
-        self.assertEqual(
-            response._csp_update, {"form-action": ["https:"]}
-        )
+        self.assertEqual(response._csp_update, {"form-action": ["https:"]})
 
     def _multi_scope_url(self):
         """Authorize URL requesting three scopes."""
@@ -412,7 +410,12 @@ class ToolAnnotationsAndInstructionsTests(TestCase):
         from mcp_server import mcp_server as global_mcp_server
 
         tools = {t.name: t for t in global_mcp_server._tool_manager.list_tools()}
-        for name in ("list_venues", "list_active_shifts", "get_player_state", "search_tracks"):
+        for name in (
+            "list_venues",
+            "list_active_shifts",
+            "get_player_state",
+            "search_tracks",
+        ):
             self.assertIsNotNone(
                 tools[name].annotations, f"{name} is missing annotations"
             )

--- a/website/tosti/tests/test_mcp.py
+++ b/website/tosti/tests/test_mcp.py
@@ -108,6 +108,51 @@ class WWWAuthenticateHeaderTests(TestCase):
         self.assertEqual(response["WWW-Authenticate"], 'Basic realm="admin"')
 
 
+class AuthorizeConsentScreenTests(TestCase):
+    """Custom TOSTI-branded consent screen with the right CSP loosening."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="consenter", password="x")
+        self.client.force_login(self.user)
+        self.application = Application.objects.create(
+            name="Test MCP client",
+            client_type=Application.CLIENT_PUBLIC,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://claude.ai/api/mcp/auth_callback",
+            user=None,
+            skip_authorization=False,
+        )
+
+    def _authorize_url(self):
+        return (
+            "/oauth/authorize/"
+            f"?client_id={self.application.client_id}"
+            "&response_type=code"
+            "&redirect_uri=https://claude.ai/api/mcp/auth_callback"
+            "&scope=read"
+            "&state=xyz"
+            "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+            "&code_challenge_method=S256"
+        )
+
+    def test_consent_screen_renders_with_tosti_base(self):
+        response = self.client.get(self._authorize_url())
+        self.assertEqual(response.status_code, 200)
+        # Uses TOSTI's base.html (the override), not the upstream package
+        # template that pulls in bootstrapcdn.
+        self.assertContains(response, "Authorise")
+        self.assertContains(response, "Test MCP client")
+        self.assertNotContains(response, "netdna.bootstrapcdn.com")
+
+    def test_consent_screen_loosens_form_action_csp(self):
+        response = self.client.get(self._authorize_url())
+        # The csp_update decorator stamps the response so the CSP middleware
+        # merges in the override.
+        self.assertEqual(
+            response._csp_update, {"form-action": ["https:"]}
+        )
+
+
 class DynamicClientRegistrationTests(TestCase):
     """RFC 7591 dynamic client registration."""
 

--- a/website/tosti/tests/test_mcp.py
+++ b/website/tosti/tests/test_mcp.py
@@ -302,6 +302,53 @@ class MCPEndpointAuthTests(TestCase):
         self.assertEqual(payload.get("jsonrpc"), "2.0")
         self.assertIn("result", payload)
         self.assertIn("tools", payload["result"]["capabilities"])
+        # MCP clients render the connector using serverInfo — name + icons
+        # decorated in TostiConfig.ready(). Without these the connector
+        # shows the generic ru.nl favicon (no longer the case).
+        server_info = payload["result"]["serverInfo"]
+        self.assertEqual(server_info["name"], "TOSTI")
+        self.assertIn("icons", server_info)
+        self.assertTrue(server_info["icons"])
+        for icon in server_info["icons"]:
+            self.assertTrue(icon["src"].startswith("http"))
+
+
+class ToolAnnotationsAndInstructionsTests(TestCase):
+    """Per-tool annotations and server instructions are wired up at startup."""
+
+    def test_read_only_tools_are_marked(self):
+        from mcp_server import mcp_server as global_mcp_server
+
+        tools = {t.name: t for t in global_mcp_server._tool_manager.list_tools()}
+        for name in ("list_venues", "list_active_shifts", "get_player_state", "search_tracks"):
+            self.assertIsNotNone(
+                tools[name].annotations, f"{name} is missing annotations"
+            )
+            self.assertTrue(
+                tools[name].annotations.readOnlyHint,
+                f"{name} should be marked read-only",
+            )
+
+    def test_write_tools_are_marked_non_destructive(self):
+        from mcp_server import mcp_server as global_mcp_server
+
+        tools = {t.name: t for t in global_mcp_server._tool_manager.list_tools()}
+        for name in ("place_order", "request_song", "create_venue_reservation"):
+            annotations = tools[name].annotations
+            self.assertIsNotNone(annotations, f"{name} is missing annotations")
+            self.assertFalse(annotations.readOnlyHint, f"{name} is not read-only")
+            self.assertFalse(
+                annotations.destructiveHint,
+                f"{name} only creates rows; should not be destructive",
+            )
+
+    def test_server_instructions_are_populated(self):
+        from mcp_server import mcp_server as global_mcp_server
+
+        instructions = global_mcp_server._mcp_server.instructions
+        self.assertTrue(instructions)
+        self.assertIn("TOSTI", instructions)
+        self.assertIn("venue", instructions.lower())
 
 
 class MCPLandingPageTests(TestCase):

--- a/website/tosti/tests/test_mcp.py
+++ b/website/tosti/tests/test_mcp.py
@@ -152,6 +152,98 @@ class AuthorizeConsentScreenTests(TestCase):
             response._csp_update, {"form-action": ["https:"]}
         )
 
+    def _multi_scope_url(self):
+        """Authorize URL requesting three scopes."""
+        return (
+            "/oauth/authorize/"
+            f"?client_id={self.application.client_id}"
+            "&response_type=code"
+            "&redirect_uri=https://claude.ai/api/mcp/auth_callback"
+            "&scope=read+orders%3Aorder+thaliedje%3Arequest"
+            "&state=xyz"
+            "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+            "&code_challenge_method=S256"
+        )
+
+    def test_consent_renders_one_checkbox_per_requested_scope(self):
+        response = self.client.get(self._multi_scope_url())
+        self.assertEqual(response.status_code, 200)
+        # One checkbox per requested scope, all checked by default.
+        for scope in ("read", "orders:order", "thaliedje:request"):
+            self.assertContains(response, f'value="{scope}"')
+            self.assertContains(response, f"<code>{scope}</code>")
+        # Scopes the client did NOT ask for must not appear as choices.
+        self.assertNotContains(response, 'value="thaliedje:manage"')
+
+    def test_granting_subset_issues_code_for_subset(self):
+        """User unchecks one scope → the issued grant matches the subset."""
+        from oauth2_provider.models import Grant
+
+        get_response = self.client.get(self._multi_scope_url())
+        form_initial = get_response.context["form"].initial
+        post_response = self.client.post(
+            "/oauth/authorize/",
+            {
+                "csrfmiddlewaretoken": "ignored-in-tests",
+                "client_id": form_initial["client_id"],
+                "state": form_initial["state"],
+                "redirect_uri": form_initial["redirect_uri"],
+                "response_type": form_initial["response_type"],
+                "code_challenge": form_initial["code_challenge"],
+                "code_challenge_method": form_initial["code_challenge_method"],
+                "requested_scope": "read orders:order thaliedje:request",
+                # User ticks only "read" — drops orders:order and thaliedje:request.
+                "scope": ["read"],
+                "allow": "Authorize",
+            },
+        )
+        self.assertEqual(post_response.status_code, 302)
+        grant = Grant.objects.get(user=self.user, application=self.application)
+        self.assertEqual(set(grant.scope.split()), {"read"})
+
+    def test_cannot_grant_scopes_not_originally_requested(self):
+        """Tampered POST with a scope the client never asked for is rejected."""
+        get_response = self.client.get(self._multi_scope_url())
+        form_initial = get_response.context["form"].initial
+        post_response = self.client.post(
+            "/oauth/authorize/",
+            {
+                "client_id": form_initial["client_id"],
+                "state": form_initial["state"],
+                "redirect_uri": form_initial["redirect_uri"],
+                "response_type": form_initial["response_type"],
+                "code_challenge": form_initial["code_challenge"],
+                "code_challenge_method": form_initial["code_challenge_method"],
+                "requested_scope": "read",
+                "scope": ["read", "thaliedje:manage"],  # not in choices
+                "allow": "Authorize",
+            },
+        )
+        # Re-renders the form with an invalid-choice error rather than
+        # issuing a grant for the unrequested scope.
+        self.assertEqual(post_response.status_code, 200)
+
+    def test_granting_zero_scopes_re_renders_with_required_error(self):
+        """Submitting with all boxes unticked must not produce a grant."""
+        get_response = self.client.get(self._multi_scope_url())
+        form_initial = get_response.context["form"].initial
+        post_response = self.client.post(
+            "/oauth/authorize/",
+            {
+                "client_id": form_initial["client_id"],
+                "state": form_initial["state"],
+                "redirect_uri": form_initial["redirect_uri"],
+                "response_type": form_initial["response_type"],
+                "code_challenge": form_initial["code_challenge"],
+                "code_challenge_method": form_initial["code_challenge_method"],
+                "requested_scope": "read orders:order",
+                "scope": [],
+                "allow": "Authorize",
+            },
+        )
+        self.assertEqual(post_response.status_code, 200)
+        self.assertContains(post_response, "Select at least one permission")
+
 
 class DynamicClientRegistrationTests(TestCase):
     """RFC 7591 dynamic client registration."""

--- a/website/tosti/urls.py
+++ b/website/tosti/urls.py
@@ -4,10 +4,10 @@ from django.contrib import admin
 from django.templatetags.static import static
 from django.urls import path, include
 from django.views.generic import RedirectView
-from oauth2_provider.views import AuthorizationView
 
 from .oauth_discovery import (
     DynamicClientRegistrationView,
+    GranularAuthorizationView,
     OAuthAuthorizationServerMetadataView,
     OAuthProtectedResourceMetadataView,
 )
@@ -32,7 +32,7 @@ from .views import (
 # global ``form-action: 'self'`` would break the flow. Loosen the directive
 # for this single view, not site-wide.
 authorize_view = csp_update({"form-action": ["https:"]})(
-    AuthorizationView.as_view()
+    GranularAuthorizationView.as_view()
 )
 
 handler403 = custom_handler403

--- a/website/tosti/urls.py
+++ b/website/tosti/urls.py
@@ -1,8 +1,10 @@
+from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import admin
 from django.templatetags.static import static
 from django.urls import path, include
 from django.views.generic import RedirectView
+from oauth2_provider.views import AuthorizationView
 
 from .oauth_discovery import (
     DynamicClientRegistrationView,
@@ -22,6 +24,15 @@ from .views import (
     AfterLoginRedirectView,
     LogoutView,
     StatisticsView,
+)
+
+# The OAuth consent screen POSTs back to /oauth/authorize/ which then 302s
+# to the client's redirect_uri (a third-party origin by design). Browsers
+# treat the post-form-submit redirect as a form-action target, so the
+# global ``form-action: 'self'`` would break the flow. Loosen the directive
+# for this single view, not site-wide.
+authorize_view = csp_update({"form-action": ["https:"]})(
+    AuthorizationView.as_view()
 )
 
 handler403 = custom_handler403
@@ -51,6 +62,14 @@ urlpatterns = [
         "oauth/docs/",
         OAuthIntegrationDocsView.as_view(),
         name="oauth-integration-docs",
+    ),
+    # Must shadow the upstream pattern (defined inside the include below) so
+    # the per-view CSP override applies. Same name & namespace as upstream so
+    # ``reverse('oauth2_provider:authorize')`` still works everywhere.
+    path(
+        "oauth/authorize/",
+        authorize_view,
+        name="authorize",
     ),
     path("oauth/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     path("privacy/", PrivacyView.as_view(), name="privacy"),

--- a/website/tosti/views.py
+++ b/website/tosti/views.py
@@ -196,10 +196,22 @@ class MCPToolsDocsView(TemplateView):
             if group_name not in grouped:
                 grouped[group_name] = {"doc": group_doc, "tools": []}
 
+            annotations = tool.annotations
+            if annotations is None:
+                kind = "unclassified"
+            elif annotations.readOnlyHint:
+                kind = "read-only"
+            elif annotations.destructiveHint:
+                kind = "destructive"
+            else:
+                kind = "write"
+
             grouped[group_name]["tools"].append(
                 {
                     "name": tool.name,
+                    "title": annotations.title if annotations else None,
                     "description": (tool.description or "").strip(),
+                    "kind": kind,
                     "input_schema": json.dumps(
                         tool.parameters, indent=2, sort_keys=True
                     ),

--- a/website/venues/mcp.py
+++ b/website/venues/mcp.py
@@ -18,6 +18,22 @@ class VenueTools(MCPToolset):
     side effect.
     """
 
+    # See ``tosti.mcp.stamp_tool_annotations`` for what these do.
+    tool_annotations = {
+        "list_venues": {
+            "readOnlyHint": True,
+            "openWorldHint": False,
+            "title": "List venues",
+        },
+        "create_venue_reservation": {
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "openWorldHint": False,
+            "title": "Create a venue reservation",
+        },
+    }
+
     def list_venues(self) -> list[dict]:
         """List all venues that can be reserved or where shifts can run.
 


### PR DESCRIPTION
## Summary

Follow-ups on #644 (which is now merged into master). Four self-contained commits, each independently reviewable:

1. **Custom TOSTI-branded OAuth consent screen with right CSP** (`c8207ab` → now `2a95968`)
   The upstream `oauth2_provider/authorize.html` extends a base that pulls Bootstrap from a CDN — blocked by our `style-src` CSP, and the post-form-submit redirect to a third-party `redirect_uri` (e.g. `claude.ai/api/mcp/auth_callback`) was blocked by `form-action: 'self'`. Override the template under `tosti/templates/oauth2_provider/authorize.html` so it extends `tosti/base.html`, and shadow `/oauth/authorize/` with the view wrapped in `@csp_update({"form-action": ["https:"]})` — single view loosened, site-wide CSP unchanged.

2. **Fix Marietje MCP tools** (`2846084` → `6d59c13`)
   `get_player_for_venue` used `Player.objects.get`, returning the base class. The base `current_track_name`/`current_artists` properties raise `NotImplementedError`, so `get_player_state` 500'd for every MarietjePlayer-backed venue. Switched to `Player.objects.select_subclasses().get` (matches the convention in `thaliedje/converters.py`). Regression test included.

3. **Brand the MCP serverInfo, add server instructions, annotate tools** (`078f92b` → `1e1ae9e`)
   - `TostiConfig.ready()` stamps `name="TOSTI"`, `website_url`, and a full icon set (absolute URLs, sidestepping the `/favicon.ico` 301 redirect) on the global MCP server's `serverInfo`. Driven by a new `TOSTI_CANONICAL_URL` setting.
   - Sets a real server-instructions block describing how to use the tools (venue slugs, shift IDs, OAuth scope failure mode, safety rules). The auto-published `get_server_instructions` tool picks this up.
   - Adds per-tool `ToolAnnotations` (`readOnlyHint`, `destructiveHint=False` for create-only tools, `openWorldHint` for `search_tracks`, titles). Source of truth is `tool_annotations` class attr on each `MCPToolset` subclass.
   - `/mcp/docs/` renders read-only / write badges per tool.
   - INSTALLED_APPS reorder: `mcp_server` runs its `ready()` *before* `tosti` so the registry is populated when we stamp.

4. **Let users grant a subset of requested OAuth scopes** (`fe1fac9` → `f56c356`)
   Upstream `AllowForm.scope` is a hidden CharField — all-or-nothing. RFC 6749 §3.3 explicitly allows granting narrower scope. `GranularAuthorizationForm` swaps `scope` for a `MultipleChoiceField` rendered as checkboxes, with a hidden `requested_scope` field that round-trips the original ask so a tampered POST can't grant an unrequested scope. PKCE / state / nonce / approval_prompt all inherited unchanged from `AuthorizationView`.

## Test plan

- [ ] CI: 208 tests pass, flake8 + black clean.
- [ ] Visit `/oauth/authorize/?...` via an actual OAuth flow → consent screen extends the TOSTI base, no CDN errors, no CSP `form-action` violation when submitting to a `claude.ai` redirect URI.
- [ ] Connect Claude Desktop (or any MCP client) → connector shows the TOSTI logo, not the generic RU favicon.
- [ ] In Claude Desktop's tool browser → tools are grouped into read / write sections (not all under "Other tools").
- [ ] On the consent screen → un-tick a scope, click Authorise → the resulting `AccessToken` carries only the ticked scopes; the Connected apps tab lists them correctly.
- [ ] Visit `/mcp` via a venue with a MarietjePlayer → `get_player_state` returns a clean state dict, not a 500.