### PR TITLE
Don't auto-start Spotify when player has no active context

### DIFF
--- a/website/thaliedje/models.py
+++ b/website/thaliedje/models.py
@@ -714,7 +714,19 @@ class SpotifyPlayer(Player):
         return queue
 
     def request_song(self, track_id):
-        """Queue a track."""
+        """Queue a track.
+
+        If the player is paused (but has an active context — i.e. something
+        is loaded), auto-start playback and skip to the just-queued track
+        so the user hears it. We deliberately do NOT auto-start when there
+        is no active context: ``start_playback`` would 403 silently
+        ("Restriction violated") and the subsequent ``next()`` would then
+        consume the just-queued track from the queue, leaving the user
+        with a "scheduled" row in the DB but nothing on Spotify. That
+        confused weekend-only testing of the MCP path; the same trap
+        applied to the website. Operators can still start the player
+        explicitly via the play endpoint.
+        """
         track_info = self.do_spotify_request(self.spotify.track, track_id)
 
         self.do_spotify_request(
@@ -723,7 +735,7 @@ class SpotifyPlayer(Player):
 
         cache.delete(self._queue_cache_key)
 
-        if not self.is_playing:
+        if not self.is_playing and self._current_playback is not None:
             self.start()
             self.next()
 

--- a/website/thaliedje/tests/test_player.py
+++ b/website/thaliedje/tests/test_player.py
@@ -1,0 +1,96 @@
+"""Tests for the Spotify/Marietje player models."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from django.test import TestCase
+
+from thaliedje.models import SpotifyPlayer
+
+
+class SpotifyPlayerRequestSongTests(TestCase):
+    """Regression tests for ``SpotifyPlayer.request_song``.
+
+    Background: when a song is queued via ``add_to_queue`` and the player
+    happens to be paused, the old implementation always called ``start()``
+    + ``next()`` to bring the user's track to the front. On a player with
+    no active context (typical off-hours state) ``start_playback`` 403s
+    silently ("Restriction violated"), and the subsequent ``next_track``
+    then *consumes* the just-queued track from Spotify's queue — leaving
+    the user with a ``SpotifyQueueItem`` row in TOSTI's DB but nothing on
+    Spotify. We now skip the auto-start when ``_current_playback`` is
+    None.
+    """
+
+    def _player(self):
+        # Use ``new`` so the model isn't saved (and we don't need a venue
+        # or unique-field setup); we only care about method behaviour.
+        return SpotifyPlayer(
+            client_id="ci",
+            client_secret="cs",
+            redirect_uri="https://example.com/cb",
+            playback_device_id="dev-1",
+        )
+
+    def _run_request_song(self, is_playing, current_playback):
+        """Drive ``request_song`` with a mocked Spotify client.
+
+        Returns the list of Spotify-API function references the player
+        attempted to call, so individual tests can assert against the set.
+        """
+        player = self._player()
+        # ``do_spotify_request`` is called from request_song for track(),
+        # add_to_queue(), and from start()/next(); patch it to a no-op.
+        player.do_spotify_request = MagicMock(return_value={"id": "track"})
+        spotify_stub = MagicMock()
+        with (
+            patch.object(
+                SpotifyPlayer,
+                "spotify",
+                new_callable=PropertyMock,
+                return_value=spotify_stub,
+            ),
+            patch.object(
+                SpotifyPlayer,
+                "is_playing",
+                new_callable=PropertyMock,
+                return_value=is_playing,
+            ),
+            patch.object(
+                SpotifyPlayer,
+                "_current_playback",
+                new_callable=PropertyMock,
+                return_value=current_playback,
+            ),
+        ):
+            player.request_song("track-id-1")
+        return spotify_stub, [
+            call.args[0] for call in player.do_spotify_request.call_args_list
+        ]
+
+    def test_does_not_auto_start_when_no_active_context(self):
+        """Player paused AND no active context → only queue, no start/next."""
+        spotify, called_funcs = self._run_request_song(
+            is_playing=False, current_playback=None
+        )
+        # add_to_queue + track were called; start_playback / next_track
+        # must NOT have been — that's what eats the queued track.
+        self.assertIn(spotify.track, called_funcs)
+        self.assertIn(spotify.add_to_queue, called_funcs)
+        self.assertNotIn(spotify.start_playback, called_funcs)
+        self.assertNotIn(spotify.next_track, called_funcs)
+
+    def test_does_auto_start_when_paused_but_has_active_context(self):
+        """Player paused but a context IS loaded → still auto-start/skip."""
+        spotify, called_funcs = self._run_request_song(
+            is_playing=False, current_playback={"some": "ctx"}
+        )
+        self.assertIn(spotify.start_playback, called_funcs)
+        self.assertIn(spotify.next_track, called_funcs)
+
+    def test_does_not_auto_start_when_already_playing(self):
+        """Player already playing → no auto-start (Spotify will play the queue itself)."""
+        spotify, called_funcs = self._run_request_song(
+            is_playing=True, current_playback={"some": "ctx"}
+        )
+        self.assertNotIn(spotify.start_playback, called_funcs)
+        self.assertNotIn(spotify.next_track, called_funcs)


### PR DESCRIPTION
## Summary

`SpotifyPlayer.request_song` queues the track and, if the player is paused, calls `start()` + `next()` to bring the just-queued track to the front. That auto-start works fine when the player has an active context (briefly paused) but breaks badly when the player is dormant — which is the typical off-hours state at the canteens.

Reproduced from this real production trace:
https://tosti.sentry.io/explore/traces/trace/7c19d5f5431e4c8d8ef93d5834059f34

Sequence:

1. `POST /me/player/queue` — **200, song added to Spotify's queue** ✅
2. `PUT /me/player/play` — **403 PERMISSION_DENIED** ("Restriction violated" — Spotify won't start playback without a context). `do_spotify_request` swallows the error.
3. `POST /me/player/next` — **200, advanced past the queued song** ❌. Spotify pops the next-up to "skip" to it, but with no current playback that just consumes the queued track.

Result: TOSTI's DB shows the `SpotifyQueueItem` row (so the song looks "scheduled" in the UI), Spotify's queue is empty, the user wonders what happened.

This trap existed for the website's queue endpoint too — it just doesn't surface in practice because the canteen player is normally playing. The MCP path made it visible during weekend-only testing.

## Fix

Skip the auto-start when `_current_playback` is None. The common case (briefly paused, context still loaded) keeps working; the dormant case stops eating queued songs. Operators can still wake the player explicitly via the dedicated play endpoint.

Tests cover all three states:
- paused + no active context → only `add_to_queue`, no `start_playback` / `next_track`
- paused + active context → still auto-starts and skips
- already playing → no auto-start

## Test plan

- [ ] CI: 216 tests pass, flake8 + black clean.
- [ ] Production smoke test: with the canteen Spotify player paused (or off-hours), request a song via the website or `/mcp` — the song should appear in the Spotify queue and stay there.
- [ ] Sanity check: with the canteen Spotify player playing, requesting a song still adds it to the queue and Spotify plays it after the current track ends (unchanged behaviour).