### PR TITLE
Give MCP search_tracks disambiguators agents can actually read

### DIFF
--- a/website/thaliedje/api/v1/views.py
+++ b/website/thaliedje/api/v1/views.py
@@ -120,18 +120,42 @@ class PlayerTrackSearchAPIView(APIView):
             "properties": {
                 "query": {"type": "string", "example": "string"},
                 "results": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {"type": "string", "example": "string"},
-                            "artists": {
-                                "type": "array",
-                                "items": {"type": "string", "example": "string"},
-                            },
-                            "id": {
-                                "type": "string",
-                                "example": "6tcCTgpI1JWsgReB9ttSUD",
+                    "type": "object",
+                    "description": (
+                        "Spotify ``search`` response, keyed by category "
+                        "(``tracks``, ``albums``, ``playlists``). Each "
+                        "category is a list of result dicts."
+                    ),
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {"type": "string"},
+                                "name": {"type": "string"},
+                                "artists": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "id": {
+                                    "type": "string",
+                                    "example": "6tcCTgpI1JWsgReB9ttSUD",
+                                },
+                                "uri": {"type": "string"},
+                                "image": {"type": "string", "nullable": True},
+                                "album": {"type": "string", "nullable": True},
+                                "album_release_date": {
+                                    "type": "string",
+                                    "nullable": True,
+                                    "description": (
+                                        "Spotify's release-date string "
+                                        "(YYYY, YYYY-MM, or YYYY-MM-DD)."
+                                    ),
+                                },
+                                "duration_ms": {
+                                    "type": "integer",
+                                    "nullable": True,
+                                },
                             },
                         },
                     },

--- a/website/thaliedje/mcp.py
+++ b/website/thaliedje/mcp.py
@@ -34,6 +34,11 @@ def search_tracks(player: Player, query: str, maximum: int = 5) -> list[dict]:
     - ``MarietjePlayer`` returns ``None`` (no search support).
 
     Normalise both to the flat list of track dicts the MCP tool promises.
+    The shape mirrors what the REST API returns so the MCP surface is a
+    strict subset of the REST surface (no MCP-only data leaks). Per-track
+    fields: ``id`` (Spotify track ID), ``name``, ``artists``, ``album``,
+    ``album_release_date``, ``duration_ms``, ``image`` (album cover URL,
+    or None).
     """
     maximum = max(1, min(int(maximum), 25))
     raw = player.search(query, maximum=maximum, query_type="track")
@@ -51,6 +56,10 @@ def search_tracks(player: Player, query: str, maximum: int = 5) -> list[dict]:
             "id": r.get("id"),
             "name": r.get("name"),
             "artists": r.get("artists", []),
+            "album": r.get("album"),
+            "album_release_date": r.get("album_release_date"),
+            "duration_ms": r.get("duration_ms"),
+            "image": r.get("image"),
         }
         for r in tracks
         if isinstance(r, dict)
@@ -110,11 +119,51 @@ class ThaliedjeTools(MCPToolset):
         }
 
     def search_tracks(self, venue_slug: str, query: str, maximum: int = 5) -> dict:
-        """Search the music catalog for tracks via a venue's player.
+        """Search the Spotify catalog for tracks playable on a venue's player.
 
-        ``venue_slug`` selects the player (each venue has its own backend —
-        Spotify or Marietje). ``query`` is a free-text search. ``maximum``
-        caps the number of results (default 5, hard ceiling 25).
+        The catalog is **Spotify's** — results are real Spotify tracks and
+        the ``id`` field on each result is a **Spotify track ID** (an
+        opaque base62 string, e.g. ``"7D5vAulNfrQV6xEwzgH0OF"``). Pass it
+        through verbatim to ``request_song``; do not parse, hash, or
+        invent it.
+
+        ``venue_slug`` selects the player. Search currently works only
+        for Spotify-backed venues; Marietje-backed venues return an
+        empty list (Marietje does not expose a catalog search). The
+        agent should not interpret an empty result on a Marietje venue
+        as "no songs match" — say so explicitly to the user.
+        ``query`` is a free-text search — Spotify will accept
+        ``track:name artist:artistname`` for more precise matching if you
+        already know both. ``maximum`` caps the number of results
+        (default 5, hard ceiling 25).
+
+        **Result order is Spotify's relevance/popularity ranking** — the
+        first entry is the best match Spotify could find, the last is the
+        weakest. A few important consequences:
+
+        - Lower-position entries may not be exact name matches; Spotify
+          sometimes surfaces other songs by the same artist. Trust
+          ``name`` + ``artists`` for relevance, not just position.
+        - The same song often exists under multiple Spotify IDs (album
+          version, single, live recording, remaster, regional release).
+          Use ``album``, ``album_release_date`` and ``duration_ms`` to
+          tell them apart when ``name`` and ``artists`` match. If the
+          user said "the original" prefer the earliest
+          ``album_release_date``; if they said "the album version"
+          prefer the entry whose ``album`` is the studio album rather
+          than a compilation or single.
+        - ``image`` is the album cover URL — surface it to the user if
+          your client renders inline images so they can confirm by sight.
+          You can also point the user at
+          ``https://open.spotify.com/track/{id}`` for a visual confirm.
+        - When in doubt with multiple plausible matches, ask the user
+          rather than guessing — every result here is genuinely a
+          distinct Spotify recording.
+
+        Per-track fields: ``id`` (Spotify track ID), ``name``,
+        ``artists`` (list of names), ``album`` (album name),
+        ``album_release_date``, ``duration_ms``, ``image`` (album cover
+        URL or ``null``).
         """
         player = get_player_for_venue(venue_slug)
         if player is None:
@@ -132,8 +181,15 @@ class ThaliedjeTools(MCPToolset):
     def request_song(self, venue_slug: str, track_id: str) -> dict:
         """Request a song to be added to a venue's player queue.
 
-        ``track_id`` is the ``id`` returned by ``search_tracks``.
+        ``track_id`` is a **Spotify track ID** (the opaque ``id`` field
+        returned by ``search_tracks``) — pass it through verbatim.
+        Do not pass a URI (``spotify:track:...``), URL, ISRC, or made-up
+        identifier; only the bare ID Spotify returned in the search.
         Requires the ``thaliedje:request`` OAuth2 scope.
+
+        Confirm with the user which specific result they want before
+        calling this — two search hits with the same ``name`` and
+        ``artists`` can be entirely different recordings.
         """
         scope_error = require_scope(self.request, "thaliedje:request")
         if scope_error:

--- a/website/thaliedje/models.py
+++ b/website/thaliedje/models.py
@@ -874,6 +874,28 @@ class SpotifyPlayer(Player):
         except KeyError:
             return []
 
+    def _project_track(self, raw):
+        """Trim a raw Spotify track payload to the shape ``search`` returns.
+
+        Covers the case Spotify occasionally hands back a track with no
+        album art (``album.images`` is ``[]``) — fall back to ``None``
+        instead of raising. Existing callers already render ``image``
+        conditionally.
+        """
+        album = raw.get("album") or {}
+        images = album.get("images") or []
+        return {
+            "type": raw["type"],
+            "name": raw["name"],
+            "artists": self.get_artists_for_spotify_track(raw),
+            "id": raw["id"],
+            "uri": raw["uri"],
+            "image": images[0]["url"] if images else None,
+            "album": album.get("name"),
+            "album_release_date": album.get("release_date"),
+            "duration_ms": raw.get("duration_ms"),
+        }
+
     @volume.setter
     def volume(self, volume_percent):
         """Set the volume of the playback device of a Player."""
@@ -924,8 +946,14 @@ class SpotifyPlayer(Player):
         :param query: the search query
         :param maximum: the maximum number of results to search for
         :param query_type: the type of the spotify instance to search
-        :return: a list of tracks [{"name": the trackname, "artists": [a list of artist names],
-         "id": the Spotify track id}]
+        :return: a list of tracks. Each track dict contains ``type``,
+         ``name``, ``artists``, ``id`` (the Spotify track id), ``uri``,
+         ``image`` (album cover URL or None when Spotify omits it),
+         ``album`` (album name), ``album_release_date`` (Spotify's
+         ``YYYY``/``YYYY-MM``/``YYYY-MM-DD`` string), and ``duration_ms``.
+         The album/duration fields exist so non-visual consumers (MCP
+         agents, headless tooling) can tell two same-name results apart
+         when the website normally relies on the album cover.
         """
         results = self.do_spotify_request(
             self.spotify.search, q=query, limit=maximum, type=query_type
@@ -944,15 +972,7 @@ class SpotifyPlayer(Player):
                     trimmed_result_for_key, key=lambda x: -x["popularity"]
                 )
                 trimmed_result_for_key = [
-                    {
-                        "type": x["type"],
-                        "name": x["name"],
-                        "artists": self.get_artists_for_spotify_track(x),
-                        "id": x["id"],
-                        "uri": x["uri"],
-                        "image": x["album"]["images"][0]["url"],
-                    }
-                    for x in trimmed_result_for_key
+                    self._project_track(x) for x in trimmed_result_for_key
                 ]
                 trimmed_result["tracks"] = trimmed_result_for_key
             elif key == "albums":

--- a/website/thaliedje/templates/thaliedje/search.html
+++ b/website/thaliedje/templates/thaliedje/search.html
@@ -19,13 +19,17 @@
                                         <img height="50" v-if="track.image !== null" :src="track.image" :alt="'Album art for ' + track.name"/>
                                     </div>
                                     <div class="flex-equal-width d-flex flex-column">
-                                        <div>
-                                            ${ track.name }$
+                                        <div class="d-flex justify-content-between">
+                                            <span>${ track.name }$</span>
+                                            <span v-if="track.duration_ms" class="text-muted small ms-2">${ formatDuration(track.duration_ms) }$</span>
                                         </div>
                                         <div style="font-style: italic;">
                                             <template v-for="(artist, art_index) in track.artists">
                                                 ${ artist }$<template v-if="art_index !== track.artists.length - 1">, </template>
                                             </template>
+                                        </div>
+                                        <div v-if="track.album" class="text-muted small text-truncate">
+                                            ${ track.album }$<template v-if="track.album_release_date"> (${ track.album_release_date.slice(0, 4) }$)</template>
                                         </div>
                                     </div>
                                     <button class="btn btn-primary" style="height: 40px" v-on:click="add_to_queue(track.id)"><i class="fa-solid fa-plus"></i></button>
@@ -121,6 +125,13 @@
             }
         },
         methods: {
+            formatDuration(ms) {
+                if (typeof ms !== 'number') return '';
+                const totalSeconds = Math.floor(ms / 1000);
+                const minutes = Math.floor(totalSeconds / 60);
+                const seconds = String(totalSeconds % 60).padStart(2, '0');
+                return `${minutes}:${seconds}`;
+            },
             tryUrl() {
                 let urlToTry = null;
                 try {

--- a/website/thaliedje/tests/test_mcp.py
+++ b/website/thaliedje/tests/test_mcp.py
@@ -106,10 +106,34 @@ class SearchTracksServiceTests(TestCase):
         player.search.return_value = raw
         return player
 
+    def _expected(self, **fields):
+        """Build the full per-track shape ``search_tracks`` returns, with
+        every disambiguator defaulting to None — the test only has to
+        specify the fields that vary.
+        """
+        return {
+            "id": None,
+            "name": None,
+            "artists": [],
+            "album": None,
+            "album_release_date": None,
+            "duration_ms": None,
+            "image": None,
+            **fields,
+        }
+
     def test_unwraps_spotify_dict_shape(self):
         raw = {
             "tracks": [
-                {"id": "1", "name": "Song A", "artists": ["Artist"]},
+                {
+                    "id": "1",
+                    "name": "Song A",
+                    "artists": ["Artist"],
+                    "album": "Album X",
+                    "album_release_date": "2005-01-01",
+                    "duration_ms": 222000,
+                    "image": "https://i.scdn.co/x.jpg",
+                },
                 {"id": "2", "name": "Song B", "artists": ["Artist 2"]},
             ],
             # other categories should be ignored by ``search_tracks``
@@ -119,8 +143,16 @@ class SearchTracksServiceTests(TestCase):
         self.assertEqual(
             result,
             [
-                {"id": "1", "name": "Song A", "artists": ["Artist"]},
-                {"id": "2", "name": "Song B", "artists": ["Artist 2"]},
+                self._expected(
+                    id="1",
+                    name="Song A",
+                    artists=["Artist"],
+                    album="Album X",
+                    album_release_date="2005-01-01",
+                    duration_ms=222000,
+                    image="https://i.scdn.co/x.jpg",
+                ),
+                self._expected(id="2", name="Song B", artists=["Artist 2"]),
             ],
         )
 
@@ -128,7 +160,7 @@ class SearchTracksServiceTests(TestCase):
         raw = [{"id": "1", "name": "Song A", "artists": ["Artist"]}]
         self.assertEqual(
             search_tracks_service(self._player(raw), "anything"),
-            [{"id": "1", "name": "Song A", "artists": ["Artist"]}],
+            [self._expected(id="1", name="Song A", artists=["Artist"])],
         )
 
     def test_none_return_is_empty_list(self):
@@ -143,4 +175,4 @@ class SearchTracksServiceTests(TestCase):
     def test_skips_non_dict_entries(self):
         raw = {"tracks": [{"id": "1"}, "stray-string", None]}
         result = search_tracks_service(self._player(raw), "x")
-        self.assertEqual(result, [{"id": "1", "name": None, "artists": []}])
+        self.assertEqual(result, [self._expected(id="1")])

--- a/website/thaliedje/tests/test_player.py
+++ b/website/thaliedje/tests/test_player.py
@@ -94,3 +94,101 @@ class SpotifyPlayerRequestSongTests(TestCase):
         )
         self.assertNotIn(spotify.start_playback, called_funcs)
         self.assertNotIn(spotify.next_track, called_funcs)
+
+
+class SpotifyPlayerSearchProjectionTests(TestCase):
+    """``SpotifyPlayer.search`` exposes album/duration disambiguators.
+
+    The REST API and the MCP both consume this — keeping the two surfaces
+    in sync is the whole point. If you remove a field here, expect
+    callers on both sides to break.
+    """
+
+    _RAW = {
+        "tracks": {
+            "items": [
+                {
+                    "type": "track",
+                    "name": "Sterrenstof",
+                    "id": "7D5vAulNfrQV6xEwzgH0OF",
+                    "uri": "spotify:track:7D5vAulNfrQV6xEwzgH0OF",
+                    "popularity": 70,
+                    "duration_ms": 222000,
+                    "artists": [{"name": "De Jeugd Van Tegenwoordig"}],
+                    "album": {
+                        "name": "Parels Voor De Zwijnen",
+                        "release_date": "2005-09-26",
+                        "images": [{"url": "https://i.scdn.co/cover.jpg"}],
+                    },
+                },
+            ]
+        }
+    }
+
+    def _player(self):
+        return SpotifyPlayer(
+            client_id="ci",
+            client_secret="cs",
+            redirect_uri="https://example.com/cb",
+            playback_device_id="dev-1",
+        )
+
+    def test_projection_includes_disambiguators(self):
+        player = self._player()
+        player.do_spotify_request = MagicMock(return_value=self._RAW)
+        with patch.object(
+            SpotifyPlayer,
+            "spotify",
+            new_callable=PropertyMock,
+            return_value=MagicMock(),
+        ):
+            track = player.search("sterrenstof", maximum=1)["tracks"][0]
+        self.assertEqual(
+            set(track),
+            {
+                "type",
+                "name",
+                "artists",
+                "id",
+                "uri",
+                "image",
+                "album",
+                "album_release_date",
+                "duration_ms",
+            },
+        )
+        self.assertEqual(track["album"], "Parels Voor De Zwijnen")
+        self.assertEqual(track["album_release_date"], "2005-09-26")
+        self.assertEqual(track["duration_ms"], 222000)
+
+    def test_empty_album_images_does_not_crash(self):
+        """Spotify occasionally returns a track with no album art."""
+        raw = {
+            "tracks": {
+                "items": [
+                    {
+                        "type": "track",
+                        "name": "Obscurity",
+                        "id": "abc",
+                        "uri": "spotify:track:abc",
+                        "popularity": 1,
+                        "artists": [],
+                        "album": {
+                            "name": "Unknown",
+                            "release_date": "1999",
+                            "images": [],
+                        },
+                    },
+                ]
+            }
+        }
+        player = self._player()
+        player.do_spotify_request = MagicMock(return_value=raw)
+        with patch.object(
+            SpotifyPlayer,
+            "spotify",
+            new_callable=PropertyMock,
+            return_value=MagicMock(),
+        ):
+            track = player.search("x", maximum=1)["tracks"][0]
+        self.assertIsNone(track["image"])


### PR DESCRIPTION
## The problem

Searching ``"sterrenstof"`` via the MCP ``search_tracks`` tool returns 5 results. Three of them are genuinely named "Sterrenstof" — but they have different Spotify IDs because they're different recordings (album version, single, regional release, …). The website shows album covers so the user can tell them apart at a glance. The MCP agent gets:

```json
{ "id": "7D5vAulNfrQV6xEwzgH0OF", "name": "Sterrenstof", "artists": ["De Jeugd Van Tegenwoordig"] }
{ "id": "4PW9WvbhNlrFoThvc7zheh", "name": "Sterrenstof", "artists": ["De Jeugd Van Tegenwoordig"] }
{ "id": "6CGXTNx0MsvLGAxU7gSHRe", "name": "Sterrenstof", "artists": ["De Jeugd Van Tegenwoordig"] }
```

The agent says, correctly, that it can't tell the difference between them.

A secondary issue: the tool docstring never told the agent that ``id`` is a **Spotify track ID** (opaque, base62) or that the catalog being searched is Spotify's. Some agents try to pass URIs, URLs, or hashes back into ``request_song``.

## What this PR does

### Add disambiguators to the search results

``album`` (album name), ``album_release_date`` (Spotify's ``YYYY[-MM[-DD]]`` string), and ``duration_ms`` join the existing ``id`` / ``name`` / ``artists`` / ``image`` fields on **both** the REST API (``/api/v1/.../search/``) and the MCP tool. The two surfaces stay aligned: the MCP exposes a strict subset of what the REST API exposes, never more. With these fields the agent can pick the right "Sterrenstof":

- ``album="Parels Voor De Zwijnen"``, ``album_release_date="2005-09-26"``, ``duration_ms=222000`` → the original studio album cut
- ``album="Singles 2005-2010"``, ``album_release_date="2010-…"`` → a compilation
- ``album="Live At Pinkpop"``, … → the live recording

### Make ``image`` resilient

Spotify occasionally returns a track with an empty ``album.images`` array. The previous code crashed with a KeyError; now ``image`` is ``None``. The front-end already handles ``image !== null``.

### Rewrite the MCP docstrings

The tool descriptions now say, explicitly:

- the catalog is Spotify's
- ``id`` is a Spotify track ID; pass it through verbatim, don't transform
- results are ordered by Spotify's **relevance/popularity** ranking — first is the best match Spotify could find, lower-position hits may not even be exact name matches
- two same-name hits are different recordings; use ``album`` + ``release_date`` + ``duration_ms`` to choose; if unsure, ask the user
- Marietje-backed venues return ``[]``; that is not "no songs match"
- ``open.spotify.com/track/{id}`` is a useful confirmation URL for the user
- ``request_song`` should confirm with the user before being called

## Test plan

- [ ] CI: 218 tests pass, flake8 + black clean, OpenAPI schema validates.
- [ ] Via Claude / Cursor: search for a song that exists in multiple recordings (e.g. "Sterrenstof", "Smells Like Teen Spirit"). Confirm the agent sees ``album``, ``album_release_date`` and ``duration_ms``, picks one, and asks the user to confirm before queueing it.
- [ ] Browser smoke test: open ``/thaliedje/<venue>/`` and search via the website. The dropdown still renders correctly; the underlying ``/api/v1/.../search/`` response now also carries ``album`` / ``album_release_date`` / ``duration_ms`` (additive — the existing fields the front-end consumes are unchanged).
- [ ] Marietje venue: ``search_tracks`` returns an empty results list as before; the new docstring tells the agent not to interpret that as "no matches".