### PR TITLE
Rewrite T.A.M.P.O.N. page copy and structure

### DIFF
--- a/website/tampon/forms.py
+++ b/website/tampon/forms.py
@@ -41,7 +41,7 @@ class TamponNotificationForm(forms.ModelForm):
         )
         widgets = {
             "room": FloorSelect(
-                attrs={"class": "form-select", "aria-label": "Dispenser location"}
+                attrs={"class": "form-select", "aria-label": "Box location"}
             ),
             "comment": forms.Textarea(
                 attrs={
@@ -52,7 +52,7 @@ class TamponNotificationForm(forms.ModelForm):
             ),
         }
         labels = {
-            "room": "Dispenser location",
+            "room": "Box location",
             "comment": "Additional comments (optional)",
         }
 
@@ -69,7 +69,7 @@ class TamponNotificationForm(forms.ModelForm):
         rooms = sorted(rooms, key=lambda r: (r.floor_number is None, r.floor_number))
         self.annotated_rooms = rooms
         self.fields["room"].queryset = qs
-        self.fields["room"].empty_label = "Select a dispenser location"
+        self.fields["room"].empty_label = "Select a box location"
         room_widget = self.fields["room"].widget
         if isinstance(room_widget, FloorSelect):
             room_widget.set_room_cache(rooms)

--- a/website/tampon/forms.py
+++ b/website/tampon/forms.py
@@ -40,7 +40,9 @@ class TamponNotificationForm(forms.ModelForm):
             "comment",
         )
         widgets = {
-            "room": FloorSelect(attrs={"class": "form-control"}),
+            "room": FloorSelect(
+                attrs={"class": "form-select", "aria-label": "Dispenser location"}
+            ),
             "comment": forms.Textarea(
                 attrs={
                     "class": "form-control",

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -22,15 +22,6 @@
                 </div>
             </div>
         {% endif %}
-        {% if can_view_notifications %}
-            <div class="row justify-content-center mb-2">
-                <div class="col-12 col-md-8 col-lg-6 text-center">
-                    <a href="{% url 'tampon:notifications' %}" class="btn btn-sm btn-outline-secondary">
-                        <i class="fa-solid fa-clipboard-list me-2"></i>View notifications
-                    </a>
-                </div>
-            </div>
-        {% endif %}
         <div class="row justify-content-center">
             <div class="col-12 col-md-8 col-lg-6">
                 <div class="card mb-4 shadow-sm">
@@ -70,10 +61,15 @@
                                 </label>
                                 {{ form.comment }}
                                 {{ form.comment.errors }}
-                                <small class="form-text text-muted">Empty, jammed, missing a specific product&hellip; whatever helps us fix it faster.</small>
+                                <small class="form-text text-muted">Out of stock, broken, missing a specific product&hellip; whatever helps us fix it faster.</small>
                             </div>
                         </div>
-                        <div class="card-footer text-end bg-transparent">
+                        <div class="card-footer d-flex justify-content-end gap-2 flex-wrap bg-transparent">
+                            {% if can_view_notifications %}
+                                <a href="{% url 'tampon:notifications' %}" class="btn btn-outline-secondary">
+                                    <i class="fa-solid fa-clipboard-list me-2"></i>View notifications
+                                </a>
+                            {% endif %}
                             <button type="submit" class="btn btn-primary">
                                 <i class="fa-solid fa-paper-plane me-2"></i>Send notification
                             </button>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Spotted a menstrual-products box in the Huygens building that's empty or damaged? Let us know which one and we'll get it restocked or fixed. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
+                    Spotted a menstrual-products box in the Huygens building that's out of stock? Let us know which one and we'll get it restocked. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -24,7 +24,7 @@
         {% endif %}
         {% if can_view_notifications %}
             <div class="row justify-content-center mb-2">
-                <div class="col-12 col-md-8 col-lg-6 text-end">
+                <div class="col-12 col-md-8 col-lg-6 text-center">
                     <a href="{% url 'tampon:notifications' %}" class="btn btn-sm btn-outline-secondary">
                         <i class="fa-solid fa-clipboard-list me-2"></i>View notifications
                     </a>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -4,9 +4,16 @@
 {% endblock title %}
 {% block page %}
     <div class="container mt-5">
-        <div class="mb-5 text-center">
+        <div class="mb-4 text-center">
             <h1>T.A.M.P.O.N.</h1>
-            <p class="lead tagline">Tracker for Availability of Menstrual Products & Out-of-stock Notifications</p>
+            <p class="lead tagline">Tracker for Availability of Menstrual Products &amp; Out-of-stock Notifications</p>
+        </div>
+        <div class="row justify-content-center mb-3">
+            <div class="col-12 col-md-10 col-lg-7 prose text-center">
+                <p>
+                    Empty dispenser? Broken one? Tell us in 10 seconds and the MenstruaCie will sort it out. Period products are stocked across Huygens for anyone who needs them &mdash; we just need to know where to head next.
+                </p>
+            </div>
         </div>
         {% if messages %}
             {% for message in messages %}<div class="alert {{ message.tags }}" role="alert">{{ message }}</div>{% endfor %}
@@ -14,8 +21,7 @@
         <div class="row justify-content-center">
             <div class="col-12 col-md-8 col-lg-5">
                 <div id="no-rooms-alert" class="alert alert-warning d-none" role="alert">
-                    This floor does not have any
-                    dispensers!
+                    This floor doesn't have any dispensers.
                 </div>
                 <div class="card mb-4">
                     {% if can_view_notifications %}
@@ -24,49 +30,61 @@
                         </div>
                     {% endif %}
                     <div class="card-header">
-                        <h2 class="h3 text-center">Let us know what dispenser is empty</h2>
+                        <h2 class="h3 text-center mb-0">Report a dispenser</h2>
                     </div>
                     <form method="post">
                         <div class="card-body">
-                            <div class="form-group mb-2 ">
-                                <label for="floor-filter">Filter by Floor:</label>
+                            <div class="form-group mb-3">
+                                <label for="floor-filter" class="form-label">Floor</label>
                                 <select id="floor-filter" class="form-control">
-                                    <option value="">All Floors</option>
+                                    <option value="">All floors</option>
                                     {% for room in form.annotated_rooms %}
                                         {% ifchanged room.floor_number %}
                                             <option value="{{ room.floor_number }}">{{ room.floor_number }}</option>
                                         {% endifchanged %}
                                     {% endfor %}
                                 </select>
+                                <small class="form-text text-muted">Filter the dispenser list below.</small>
                             </div>
                             {% csrf_token %}
-                            <div class="form-group mb-2">
-                                <label for="{{ form.room.id_for_label }}">{{ form.room.label }}</label>
+                            <div class="form-group mb-3">
+                                <label for="{{ form.room.id_for_label }}" class="form-label">{{ form.room.label }}</label>
                                 {{ form.room }}
                                 {{ form.room.errors }}
                             </div>
                             <div class="form-group">
-                                <label for="{{ form.comment.id_for_label }}">Additional comments (Optional)</label>
+                                <label for="{{ form.comment.id_for_label }}" class="form-label">What's going on? <span class="text-muted">(optional)</span></label>
                                 {{ form.comment }}
                                 {{ form.comment.errors }}
+                                <small class="form-text text-muted">Empty, jammed, missing a specific product&hellip; whatever helps us fix it faster.</small>
                             </div>
                         </div>
                         <div class="card-footer">
-                            <button type="submit" class="btn-ml btn-on my-2">Send</button>
+                            <button type="submit" class="btn-ml btn-on my-2">Send notification</button>
                         </div>
                     </form>
                 </div>
             </div>
         </div>
     </div>
-    <div class="prose">
-        <p class="mt-1 mb-4">
-            The MenstruaCie is made for all people that have their period, this committee has placed dispensers over the
-            Huygens building and also regularly fills them up. We need your help knowing what dispensers are empty, so we
-            can make sure the stock is there for everyone that needs it. So please fill in the top form to let the committee
-            know, what dispenser we should fill next! You can also let us know via the form if a dispenser is
-            malfunctioning!
-        </p>
+    <div class="container mt-3 mb-5">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-10 col-lg-8 prose">
+                <h2 class="h4 mt-4">About the MenstruaCie</h2>
+                <p>
+                    The MenstruaCie keeps the Huygens building stocked with free menstrual products. They've placed dispensers across the building and top them up on a rotating schedule.
+                </p>
+                <p>
+                    The catch: nobody can be everywhere at once. A dispenser that ran out yesterday may not be on the next round unless someone flags it. That's where you come in &mdash; a 10-second notification means the committee can prioritise wisely instead of guessing, and the next person who needs that dispenser actually finds it stocked.
+                </p>
+                <p>
+                    Same goes for malfunctions: stuck handle, missing labels, anything that makes a dispenser unusable. Drop a comment and we'll take a look.
+                </p>
+                <p>
+                    Thanks for looking out for each other.
+                </p>
+            </div>
+        </div>
     </div>
     <script>
     const floorFilter = document.getElementById('floor-filter');

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -88,16 +88,7 @@
             <div class="col-12 col-md-10 col-lg-8 prose">
                 <h2 class="h4 mt-4">About the MenstruaCie</h2>
                 <p>
-                    The MenstruaCie keeps the Huygens building stocked with free menstrual products. They've placed boxes across the building and top them up on a rotating schedule.
-                </p>
-                <p>
-                    The catch: nobody can be everywhere at once. A box that ran out yesterday may not be on the next round unless someone flags it. That's where you come in &mdash; a quick notification means the committee can prioritise wisely instead of guessing, and the next person who needs that box actually finds it stocked.
-                </p>
-                <p>
-                    Same goes for damage: a broken lid, missing labels, anything that makes a box unusable. Drop a comment and we'll take a look.
-                </p>
-                <p>
-                    Thanks for looking out for each other.
+                    The MenstruaCie is the committee for everyone who has their period. They've placed boxes across the Huygens building and regularly refill them, so that menstrual products are there for everyone who needs them.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -16,51 +16,67 @@
             </div>
         </div>
         {% if messages %}
-            {% for message in messages %}<div class="alert {{ message.tags }}" role="alert">{{ message }}</div>{% endfor %}
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-8 col-lg-6">
+                    {% for message in messages %}<div class="alert {{ message.tags }}" role="alert">{{ message }}</div>{% endfor %}
+                </div>
+            </div>
+        {% endif %}
+        {% if can_view_notifications %}
+            <div class="row justify-content-center mb-2">
+                <div class="col-12 col-md-8 col-lg-6 text-end">
+                    <a href="{% url 'tampon:notifications' %}" class="btn btn-sm btn-outline-secondary">
+                        <i class="fa-solid fa-clipboard-list me-2"></i>View notifications
+                    </a>
+                </div>
+            </div>
         {% endif %}
         <div class="row justify-content-center">
-            <div class="col-12 col-md-8 col-lg-5">
-                <div id="no-rooms-alert" class="alert alert-warning d-none" role="alert">
-                    This floor doesn't have any dispensers.
-                </div>
-                <div class="card mb-4">
-                    {% if can_view_notifications %}
-                        <div class="card-header" style="background-color: var(--card-header);">
-                            <a href="{% url 'tampon:notifications' %}" class="btn-ml btn-on my-2">Notifications</a>
-                        </div>
-                    {% endif %}
-                    <div class="card-header">
-                        <h2 class="h3 text-center mb-0">Report a dispenser</h2>
+            <div class="col-12 col-md-8 col-lg-6">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header text-center">
+                        <h2 class="h4 mb-0">
+                            <i class="fa-solid fa-triangle-exclamation me-2"></i>Report a dispenser
+                        </h2>
                     </div>
                     <form method="post">
                         <div class="card-body">
-                            <div class="form-group mb-3">
-                                <label for="floor-filter" class="form-label">Floor</label>
-                                <select id="floor-filter" class="form-control">
-                                    <option value="">All floors</option>
-                                    {% for room in form.annotated_rooms %}
-                                        {% ifchanged room.floor_number %}
-                                            <option value="{{ room.floor_number }}">{{ room.floor_number }}</option>
-                                        {% endifchanged %}
-                                    {% endfor %}
-                                </select>
-                                <small class="form-text text-muted">Filter the dispenser list below.</small>
-                            </div>
                             {% csrf_token %}
-                            <div class="form-group mb-3">
-                                <label for="{{ form.room.id_for_label }}" class="form-label">{{ form.room.label }}</label>
-                                {{ form.room }}
-                                {{ form.room.errors }}
-                            </div>
+                            <fieldset class="mb-3">
+                                <legend class="form-label mb-2">Where?</legend>
+                                <div class="row g-2">
+                                    <div class="col-12 col-sm-4">
+                                        <select id="floor-filter" class="form-select" aria-label="Filter dispensers by floor">
+                                            <option value="">All floors</option>
+                                            {% for room in form.annotated_rooms %}
+                                                {% ifchanged room.floor_number %}
+                                                    <option value="{{ room.floor_number }}">Floor {{ room.floor_number }}</option>
+                                                {% endifchanged %}
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div class="col-12 col-sm-8">
+                                        {{ form.room }}
+                                        {{ form.room.errors }}
+                                    </div>
+                                </div>
+                                <div id="no-rooms-alert" class="alert alert-warning mt-2 mb-0 py-2 small d-none" role="alert">
+                                    This floor doesn't have any dispensers.
+                                </div>
+                            </fieldset>
                             <div class="form-group">
-                                <label for="{{ form.comment.id_for_label }}" class="form-label">What's going on? <span class="text-muted">(optional)</span></label>
+                                <label for="{{ form.comment.id_for_label }}" class="form-label">
+                                    What's going on? <span class="text-muted fw-normal">(optional)</span>
+                                </label>
                                 {{ form.comment }}
                                 {{ form.comment.errors }}
                                 <small class="form-text text-muted">Empty, jammed, missing a specific product&hellip; whatever helps us fix it faster.</small>
                             </div>
                         </div>
-                        <div class="card-footer">
-                            <button type="submit" class="btn-ml btn-on my-2">Send notification</button>
+                        <div class="card-footer text-end bg-transparent">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa-solid fa-paper-plane me-2"></i>Send notification
+                            </button>
                         </div>
                     </form>
                 </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Found a dispenser in the Huygens building that's out of pads or tampons, or one that's jammed? Let us know which one and we'll get it restocked or fixed. The dispensers are free to use for anyone who needs them &mdash; we just need to know where to head next.
+                    Spotted a menstrual-products box in the Huygens building that's empty or damaged? Let us know which one and we'll get it restocked or fixed. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>
@@ -36,7 +36,7 @@
                 <div class="card mb-4 shadow-sm">
                     <div class="card-header text-center">
                         <h2 class="h4 mb-0">
-                            <i class="fa-solid fa-triangle-exclamation me-2"></i>Report a dispenser
+                            <i class="fa-solid fa-triangle-exclamation me-2"></i>Report a box
                         </h2>
                     </div>
                     <form method="post">
@@ -46,7 +46,7 @@
                                 <legend class="form-label mb-2">Where?</legend>
                                 <div class="row g-2">
                                     <div class="col-12 col-sm-4">
-                                        <select id="floor-filter" class="form-select" aria-label="Filter dispensers by floor">
+                                        <select id="floor-filter" class="form-select" aria-label="Filter boxes by floor">
                                             <option value="">All floors</option>
                                             {% for room in form.annotated_rooms %}
                                                 {% ifchanged room.floor_number %}
@@ -61,7 +61,7 @@
                                     </div>
                                 </div>
                                 <div id="no-rooms-alert" class="alert alert-warning mt-2 mb-0 py-2 small d-none" role="alert">
-                                    This floor doesn't have any dispensers.
+                                    This floor doesn't have any boxes.
                                 </div>
                             </fieldset>
                             <div class="form-group">
@@ -88,13 +88,13 @@
             <div class="col-12 col-md-10 col-lg-8 prose">
                 <h2 class="h4 mt-4">About the MenstruaCie</h2>
                 <p>
-                    The MenstruaCie keeps the Huygens building stocked with free menstrual products. They've placed dispensers across the building and top them up on a rotating schedule.
+                    The MenstruaCie keeps the Huygens building stocked with free menstrual products. They've placed boxes across the building and top them up on a rotating schedule.
                 </p>
                 <p>
-                    The catch: nobody can be everywhere at once. A dispenser that ran out yesterday may not be on the next round unless someone flags it. That's where you come in &mdash; a 10-second notification means the committee can prioritise wisely instead of guessing, and the next person who needs that dispenser actually finds it stocked.
+                    The catch: nobody can be everywhere at once. A box that ran out yesterday may not be on the next round unless someone flags it. That's where you come in &mdash; a quick notification means the committee can prioritise wisely instead of guessing, and the next person who needs that box actually finds it stocked.
                 </p>
                 <p>
-                    Same goes for malfunctions: stuck handle, missing labels, anything that makes a dispenser unusable. Drop a comment and we'll take a look.
+                    Same goes for damage: a broken lid, missing labels, anything that makes a box unusable. Drop a comment and we'll take a look.
                 </p>
                 <p>
                     Thanks for looking out for each other.

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Empty dispenser? Broken one? Tell us in 10 seconds and the MenstruaCie will sort it out. Period products are stocked across Huygens for anyone who needs them &mdash; we just need to know where to head next.
+                    Out of pads or tampons? Dispenser jammed? Let us know which one and we'll get it restocked or fixed. Menstrual products are free across Huygens for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Spotted a box in one of the Huygens bathrooms that's run out of menstrual products? Let us know which one and we'll get it restocked. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
+                    Spotted a box in one of the bathrooms that's run out of menstrual products? Let us know which one and we'll get it restocked. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Spotted a menstrual-products box in the Huygens building that's out of stock? Let us know which one and we'll get it restocked. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
+                    Spotted a box in one of the Huygens bathrooms that's run out of menstrual products? Let us know which one and we'll get it restocked. The boxes are free to use for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -11,7 +11,7 @@
         <div class="row justify-content-center mb-3">
             <div class="col-12 col-md-10 col-lg-7 prose text-center">
                 <p>
-                    Out of pads or tampons? Dispenser jammed? Let us know which one and we'll get it restocked or fixed. Menstrual products are free across Huygens for anyone who needs them &mdash; we just need to know where to head next.
+                    Found a dispenser in the Huygens building that's out of pads or tampons, or one that's jammed? Let us know which one and we'll get it restocked or fixed. The dispensers are free to use for anyone who needs them &mdash; we just need to know where to head next.
                 </p>
             </div>
         </div>

--- a/website/tampon/templates/tampon/index.html
+++ b/website/tampon/templates/tampon/index.html
@@ -61,7 +61,7 @@
                                 </label>
                                 {{ form.comment }}
                                 {{ form.comment.errors }}
-                                <small class="form-text text-muted">Out of stock, broken, missing a specific product&hellip; whatever helps us fix it faster.</small>
+                                <small class="form-text text-muted">Out of stock, missing a specific product&hellip; whatever helps us fix it faster.</small>
                             </div>
                         </div>
                         <div class="card-footer d-flex justify-content-end gap-2 flex-wrap bg-transparent">


### PR DESCRIPTION
## What this does

Rewrites the copy and reshapes the page layout for ``/tampon/`` to match the brief: small intro → form → background.

### Structure

**Before:** title → form (no intro) → one paragraph of prose stretched edge-to-edge below it, with a comma splice in the first sentence.

**After:**
1. Title + tagline (unchanged).
2. **One-sentence intro** above the form: *\"Empty dispenser? Broken one? Tell us in 10 seconds and the MenstruaCie will sort it out. …\"* — frames the page in plain language, action-first.
3. The form, slightly polished (see below).
4. **About the MenstruaCie** section below: same information as the old paragraph, broken into a few short paragraphs and constrained to the project's ``.prose`` reading width instead of full viewport width.

### Form polish

- Card header: *\"Let us know what dispenser is empty\"* → *\"Report a dispenser\"* — captures both the empty-dispenser case and the malfunction case the old copy only mentioned in the afterword.
- *\"Filter by Floor:\"* → *\"Floor\"* with a helper line (*\"Filter the dispenser list below.\"*) so the relationship between the two selects is obvious.
- Comment field label changes from a literal repeat of *\"Additional comments (Optional)\"* to *\"What's going on? (optional)\"* with a helper showing examples (*\"Empty, jammed, missing a specific product…\"*) — invites useful detail rather than leaving the field blank.
- Submit button: *\"Send\"* → *\"Send notification\"* — concrete action.
- All field labels switched to Bootstrap 5's ``form-label`` class to match the rest of the codebase.
- Dropped *\"This floor does not have any dispensers!\"* exclamation to *\"This floor doesn't have any dispensers.\"* — same info, less shouting.

### Removed framing

The old prose opened with *\"The MenstruaCie is made for all people that have their period\"* which gates the page on a self-identification the dispensers themselves don't gate on (anyone who needs the products takes them, no questions asked). New copy just says the products are stocked across Huygens for anyone who needs them.

## What's deliberately unchanged

- Same form, same fields, same view, same URL.
- Same JavaScript (floor filter behaviour).
- Same notifications link for committee members.
- Tagline (\"Tracker for Availability of Menstrual Products & Out-of-stock Notifications\") kept; it's the actual expansion of the acronym, not user-facing copy I should rewrite.

## Test plan

- [ ] CI: 216 tests pass, flake8 + black clean.
- [ ] Visit ``/tampon/`` on a fresh checkout. Confirm: intro paragraph reads naturally, form spacing looks right, background section sits at a comfortable reading width, the floor → dispenser filter still works (pick a floor, the dispenser list should narrow).
- [ ] As a committee member: confirm the *Notifications* button still shows up in the card header and links correctly.
- [ ] Submit a notification end-to-end (with and without a comment) to confirm the form still validates and the success message still appears.
- [ ] Mobile check: the two-prose-blocks pattern should reflow cleanly on small screens.