### PR TITLE
Rewrite the Thaliedje index copy

### DIFF
--- a/website/thaliedje/templates/thaliedje/index.html
+++ b/website/thaliedje/templates/thaliedje/index.html
@@ -10,7 +10,7 @@
         <div class="row justify-content-center mb-4">
             <div class="col-12 col-md-10 col-lg-8 prose text-center">
                 <p class="mb-2">
-                    Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and &mdash; where it's supported &mdash; queue up a song of your own for everyone in that canteen to hear next.
+                    Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and queue up a song of your own for everyone to hear next.
                 </p>
                 <p class="text-muted small mb-0">
                     Sign in with your Radboud account to request songs. You can see what's playing without signing in.

--- a/website/thaliedje/templates/thaliedje/index.html
+++ b/website/thaliedje/templates/thaliedje/index.html
@@ -10,7 +10,7 @@
         <div class="row justify-content-center mb-4">
             <div class="col-12 col-md-10 col-lg-8 prose text-center">
                 <p class="mb-2">
-                    Thaliedje is the shared jukebox for the student canteens in the Huygens building. Pick a canteen below, search for a song, and queue it up &mdash; everyone hearing the music in that canteen gets to hear what you picked next.
+                    Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and &mdash; where it's supported &mdash; queue up a song of your own for everyone in that canteen to hear next.
                 </p>
                 <p class="text-muted small mb-0">
                     Sign in with your Radboud account to request songs. You can see what's playing without signing in.

--- a/website/thaliedje/templates/thaliedje/index.html
+++ b/website/thaliedje/templates/thaliedje/index.html
@@ -10,7 +10,7 @@
         <div class="row justify-content-center mb-4">
             <div class="col-12 col-md-10 col-lg-8 prose text-center">
                 <p class="mb-2">
-                    Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and queue up a song of your own for everyone to hear next.
+                    Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and request a song of your own for everyone to hear next.
                 </p>
                 <p class="text-muted small mb-0">
                     Sign in with your Radboud account to request songs. You can see what's playing without signing in.

--- a/website/thaliedje/templates/thaliedje/index.html
+++ b/website/thaliedje/templates/thaliedje/index.html
@@ -3,13 +3,19 @@
 
 {% block page %}
     <div class="container mt-5">
-        <div class="mb-5 text-center">
+        <div class="mb-4 text-center">
             <h1><i class="fa-brands fa-spotify me-4" aria-hidden="true"></i>T.h.a.l.i.e.d.j.e.</h1>
             <p class="lead tagline">Thalia's Harmonized Application for Listening to Instrumental Entertainment as a Digital Jukebox Experience</p>
         </div>
-        <div class="prose">
-            <p class="my-1">Thaliedje is the music control system for the student canteens in the Huygens building.</p>
-            <p class="mt-1 mb-5">You can add songs to the queue of the canteens by selecting a canteen below and adding your song.</p>
+        <div class="row justify-content-center mb-4">
+            <div class="col-12 col-md-10 col-lg-8 prose text-center">
+                <p class="mb-2">
+                    Thaliedje is the shared jukebox for the student canteens in the Huygens building. Pick a canteen below, search for a song, and queue it up &mdash; everyone hearing the music in that canteen gets to hear what you picked next.
+                </p>
+                <p class="text-muted small mb-0">
+                    Sign in with your Radboud account to request songs. You can see what's playing without signing in.
+                </p>
+            </div>
         </div>
         <div class="row-cols-1 row-cols-lg-3 justify-content-center d-flex flex-wrap">
             {% render_players %}


### PR DESCRIPTION
## What this does

The Thaliedje landing page (``/thaliedje/``) opened with two flat lines:

> Thaliedje is the music control system for the student canteens in the Huygens building.
> You can add songs to the queue of the canteens by selecting a canteen below and adding your song.

Same information, less wooden, in the same voice as the recent T.A.M.P.O.N. copy rewrite.

**New copy:**

> Thaliedje shows you what's playing in the student canteens in the Huygens building. Pick a canteen below to see the current track and queue, and request a song of your own for everyone to hear next.
>
> Sign in with your Radboud account to request songs. You can see what's playing without signing in.

### Why this phrasing

- Leads with *\"shows you what's playing\"*, which is universally true — both canteens display the current track, even the Marietje-backed one where requests aren't supported. The old *\"music control system\"* implied write-access everywhere; the new copy doesn't.
- *\"Pick a canteen below to see the current track and queue\"* points at the actual flow that the player cards below the copy then deliver.
- *\"Request a song of your own for everyone to hear next\"* names the social side directly without naming a specific canteen — works whether request-capability is available or not.
- Helper line makes the auth model explicit: read-only without an account, request songs with one. Was implicit before.

### Layout

Wrapped in the project's standard ``.prose`` column at ``col-lg-8`` so the copy sits at a comfortable reading width instead of stretching edge-to-edge above the player cards.

## Test plan

- [ ] CI: 216 tests pass, flake8 + black clean.
- [ ] Visit ``/thaliedje/``: new copy appears above the player cards, reads naturally, doesn't push the cards below the fold on a typical screen.
- [ ] Mobile check: the centred prose block reflows cleanly on small screens.
- [ ] Marietje-backed venue (Zuidkantine) check: the copy doesn't promise queueing where it doesn't exist.