### PR TITLE
Rewrite the Fridges index copy

### DIFF
--- a/website/fridges/templates/fridges/index.html
+++ b/website/fridges/templates/fridges/index.html
@@ -3,22 +3,25 @@
 
 {% block page %}
     <div class="container mt-5">
-        <div class="mb-5 text-center">
+        <div class="mb-4 text-center">
             <h1><i class="fa-solid fa-beer-mug-empty me-4" aria-hidden="true"></i>F.r.i.d.g.e.s.</h1>
             <p class="lead tagline">Framework Restricting Inventory of Drinks for Guaranteed Enjoyment to Students</p>
         </div>
-        <div class="prose">
-            <p class="mt-1 mb-2">Fancy a beer? Perhaps, the beer fridge is open!</p>
-            {% if user.is_authenticated %}
-            <p class="mt-1 mb-4">
-                Use your personal QR code at the top to identify yourself and open the fridge (only during opening hours).
-                Don't forget to proof your age via <a href="{% url 'users:account' %}?active=age">your profile page</a> first!
-            </p>
-            {% else %}
-            <p class="mt-1 mb-4">
-                Login and use your personal QR code to identify yourself and open the fridge (only during opening hours).
-            </p>
-            {% endif %}
+        <div class="row justify-content-center mb-4">
+            <div class="col-12 col-md-10 col-lg-8 prose text-center">
+                <p class="mb-2">
+                    Fancy a beer? Hold the personal QR code at the top of this page up to the fridge during opening hours and it'll let you in. The status below tells you which fridge is open right now.
+                </p>
+                {% if user.is_authenticated %}
+                    <p class="text-muted small mb-0">
+                        First time? Make sure you've verified your age on <a href="{% url 'users:account' %}?active=age">your profile page</a> &mdash; the fridge won't open without it.
+                    </p>
+                {% else %}
+                    <p class="text-muted small mb-0">
+                        Sign in with your Radboud account to get a personal QR code, and verify your age on your profile page before the fridge will open for you.
+                    </p>
+                {% endif %}
+            </div>
         </div>
         <div class="row-cols-1 row-cols-lg-3 justify-content-center d-flex flex-wrap">
             {% for fridge in fridges %}


### PR DESCRIPTION
## What this does

The Fridges landing page (``/fridges/``) opened with:

> Fancy a beer? Perhaps, the beer fridge is open!
>
> *(signed in)* Use your personal QR code at the top to identify yourself and open the fridge (only during opening hours). Don't forget to proof your age via your profile page first!
>
> *(signed out)* Login and use your personal QR code to identify yourself and open the fridge (only during opening hours).

Same voice as the recent T.A.M.P.O.N. and Thaliedje copy rewrites — describe the actual interaction, point at the page's interactive bit, and make the prerequisites explicit instead of letting the user discover them by failing.

**New copy:**

> Fancy a beer? Hold the personal QR code at the top of this page up to the fridge during opening hours and it'll let you in. The status below tells you which fridge is open right now.
>
> *(signed in)* First time? Make sure you've verified your age on your profile page — the fridge won't open without it.
>
> *(signed out)* Sign in with your Radboud account to get a personal QR code, and verify your age on your profile page before the fridge will open for you.

### Why this phrasing

- *\"Hold the personal QR code at the top of this page up to the fridge\"* names the actual physical interaction (the user holds their phone with the QR code up to a reader on the fridge), instead of the abstract *\"identify yourself and open the fridge\"*.
- *\"The status below tells you which fridge is open right now\"* bridges to the fridge cards rendered below the copy. The old version didn't reference them at all.
- *\"First time? Make sure you've verified your age…\"* is actionable instead of a generic *\"don't forget\"*. Drops the typo *\"proof\"* → *\"verified\"*.
- The signed-out branch now makes the two-step setup explicit (sign in → verify age → fridge opens), so a new user doesn't sign in expecting the fridge to open and then bounce off a silent age check.

### What this deliberately does NOT do

Per AGENTS.md's note that ``fridges`` / ``age`` carry legal-compliance weight, this PR is **pure copy**:

- No gating logic, model fields, view behaviour, or template-rendered state touched.
- No claim about who can/can't use the fridge that wasn't already implied by the old copy.
- ``(only during opening hours)`` constraint is preserved (folded into the main sentence rather than parenthesised at the end).
- Age verification stays explicitly required.

## Test plan

- [ ] CI: 216 tests pass, flake8 + black clean.
- [ ] Visit ``/fridges/`` signed out: new intro renders, signed-out helper line is shown, the fridge cards still appear below.
- [ ] Visit ``/fridges/`` signed in (age verified): signed-in helper line is shown, link to ``?active=age`` works.
- [ ] Visit ``/fridges/`` signed in (age NOT verified): signed-in helper line tells the user where to verify. Confirm the actual gating still behaves the same (no behavioural changes were made — this just verifies nothing broke).
- [ ] Mobile check: the centred prose block reflows cleanly above the fridge cards.