### PR TITLE
Tighten the OAuth integration docs around authorization-code + PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Specific configuration is managed through Django Constance for runtime settings:
 
 ## 📡 API
 
-TOSTI provides a RESTful API with OAuth2 authentication.
+TOSTI provides a RESTful API with OAuth 2.0 authentication. **For any integration with TOSTI you should use the authorization-code grant with PKCE** — see the [OAuth integration guide](/oauth/docs/) on a running deployment for the full flow, scopes, registration, and tokens.
 
 ### Available Scopes
 - `read`: Read access to the API

--- a/website/tosti/oauth_discovery.py
+++ b/website/tosti/oauth_discovery.py
@@ -58,23 +58,29 @@ class OAuthAuthorizationServerMetadataView(View):
                 request, "oauth-dynamic-client-registration"
             ),
             "scopes_supported": scopes,
-            # We intentionally do NOT advertise the deprecated implicit and
-            # password grants (or the corresponding "token" response_type)
-            # even though the underlying library still serves them — RFC 8414
-            # metadata should reflect the *recommended* surface for new
-            # clients. The Swagger UI uses implicit internally; that's
-            # independent of what we tell external clients.
+            # RFC 8414 metadata reflects the *recommended* surface for new
+            # clients, not everything the underlying library can serve:
+            # - implicit / password are deprecated by OAuth 2.1 — never
+            #   advertised, even though django-oauth-toolkit still accepts
+            #   them. (Swagger UI uses implicit internally; that's
+            #   independent of what we tell external clients.)
+            # - client_credentials is intentionally NOT advertised either:
+            #   server-to-server access is a maintainer-issued exception
+            #   (confidential client provisioned out of band), not a path
+            #   we want third parties to discover and try. Discovery only
+            #   advertises the authorization_code + refresh_token flow.
             "response_types_supported": ["code"],
             "grant_types_supported": [
                 "authorization_code",
-                "client_credentials",
                 "refresh_token",
             ],
-            "token_endpoint_auth_methods_supported": [
-                "client_secret_post",
-                "client_secret_basic",
-                "none",
-            ],
+            # Only token-endpoint methods relevant to the public flow:
+            # public clients (DCR, account-page registration) authenticate
+            # with ``none`` + PKCE. ``client_secret_basic`` /
+            # ``client_secret_post`` are still accepted by the library for
+            # maintainer-issued confidential clients but aren't advertised
+            # — see the grant_types_supported comment above.
+            "token_endpoint_auth_methods_supported": ["none"],
             # Only S256 is advertised; PKCE best practice (RFC 7636 §4.2)
             # mandates S256 whenever the client can compute it. The library
             # still accepts ``plain`` if a client insists.

--- a/website/tosti/templates/tosti/oauth_integration.html
+++ b/website/tosti/templates/tosti/oauth_integration.html
@@ -32,43 +32,35 @@
 
         <hr>
 
-        <h2>Supported grant types</h2>
+        <h2>Which flow to use</h2>
         <p>
-            TOSTI only supports the Authorization code grant type with PKCE.
+            <strong>For any integration with TOSTI you should use the authorization-code grant with PKCE.</strong> It's the flow our documentation, tooling and examples are written for, and the only one we'd recommend planning around. Refresh tokens are part of the same flow so long-running clients don't have to keep prompting the user.
         </p>
         <h3>Authorization code with PKCE</h3>
         <p>
-            The standard interactive flow: redirect the user to <code>/oauth/authorize/</code> with a code challenge, get a code back at your redirect URI, exchange the code (plus the code verifier) at <code>/oauth/token/</code> for an access token. PKCE (<a href="https://www.rfc-editor.org/rfc/rfc7636">RFC 7636</a>) is <strong>required</strong> for all clients; you do not get to opt out. Both <code>S256</code> and <code>plain</code> code challenge methods are supported; pick <code>S256</code>.
+            The standard interactive flow: redirect the user to <code>/oauth/authorize/</code> with a code challenge, get a code back at your redirect URI, exchange the code (plus the code verifier) at <code>/oauth/token/</code> for an access token. PKCE (<a href="https://www.rfc-editor.org/rfc/rfc7636">RFC 7636</a>) is <strong>required</strong> for every client. Use the <code>S256</code> code-challenge method.
         </p>
         <h3>Refresh token</h3>
         <p>
             When an access token expires, exchange the refresh token at <code>/oauth/token/</code> for a new pair. <strong>Refresh tokens are rotated</strong> &mdash; the response includes a new refresh token, and the old one is invalidated. Keep only the most recent one. Access tokens last 10 hours; refresh tokens do not expire on a timer but are revoked when the user revokes the application's access.
         </p>
-
-        <hr>
-
-        <h2>Client types and authentication</h2>
-        <p>
-            All clients you create within TOSTI are public clients, following the OAuth 2.0 spec.
+        <p class="text-muted">
+            If authorization code + PKCE genuinely can't cover your use case, get in touch with the website committee before building something else.
         </p>
 
         <hr>
 
         <h2>Registering a client</h2>
         <p>
-            There are three ways to get a <code>client_id</code> + (optionally) <code>client_secret</code>, depending on who you are:
+            Two ways to get a <code>client_id</code>, depending on who you are. Both produce a public client &mdash; no client secret, PKCE mandatory.
         </p>
         <h3>Through your account page <small class="text-muted">(developers)</small></h3>
         <p>
-            Log in, open <a href="{% url 'users:account' %}?active=api_credentials">My account &rarr; API credentials</a> and click <em>Create new application</em>. This is the right path if you're building your own integration against the TOSTI API and want a confidential client. Your client secret is only shown once at creation time &mdash; copy it then.
+            Log in, open <a href="{% url 'users:account' %}?active=api_credentials">My account &rarr; API credentials</a> and click <em>Create new application</em>. You'll get a <code>client_id</code> &mdash; the public-client setup means there's no secret to copy.
         </p>
         <h3>Dynamic client registration <small class="text-muted">(MCP clients, AI assistants)</small></h3>
         <p>
-            Public clients can self-register without human intervention by POSTing to <code>/oauth/register/</code> per <a href="https://www.rfc-editor.org/rfc/rfc7591">RFC 7591</a>. TOSTI always issues a public, authorization-code-only client with PKCE required; the response has no <code>client_secret</code>. Registration is rate-limited per IP (10 per hour) to protect the Application table. The client is provisioned with the intersection of the scopes you request and the scopes TOSTI publishes.
-        </p>
-        <h3>Asking a maintainer <small class="text-muted">(special cases)</small></h3>
-        <p>
-            If you need something neither of the above gives you &mdash; for example, a confidential client for client-credentials grant &mdash; ask the website committee.
+            Clients can self-register without human intervention by POSTing to <code>/oauth/register/</code> per <a href="https://www.rfc-editor.org/rfc/rfc7591">RFC 7591</a>. Registration is rate-limited per IP (10 per hour) to protect the Application table. The issued client is provisioned with the intersection of the scopes you request and the scopes TOSTI publishes.
         </p>
 
         <hr>

--- a/website/tosti/tests/test_mcp.py
+++ b/website/tosti/tests/test_mcp.py
@@ -52,14 +52,26 @@ class OAuthDiscoveryTests(TestCase):
         for scope in ("read", "write", "orders:order", "thaliedje:request"):
             self.assertIn(scope, data["scopes_supported"])
 
-    def test_authorization_server_metadata_does_not_advertise_deprecated_grants(self):
+    def test_authorization_server_metadata_only_advertises_recommended_flow(self):
+        """Discovery metadata reflects what we support for *new* integrations,
+        not the full library surface.
+
+        Authorization-code (with refresh) is the public flow. Implicit and
+        password are OAuth 2.1-deprecated. Client credentials is a
+        maintainer-issued exception (confidential client out of band) —
+        not a public capability we want third parties to discover.
+        """
         response = self.client.get(reverse("oauth-authorization-server-metadata"))
         data = json.loads(response.content)
-        # OAuth 2.1 deprecates implicit and password; do not advertise them
-        # even though the underlying library still serves them.
-        self.assertNotIn("implicit", data["grant_types_supported"])
-        self.assertNotIn("password", data["grant_types_supported"])
-        self.assertNotIn("token", data["response_types_supported"])
+        self.assertEqual(
+            sorted(data["grant_types_supported"]),
+            ["authorization_code", "refresh_token"],
+        )
+        self.assertEqual(data["response_types_supported"], ["code"])
+        # Public-client-only auth at the token endpoint (PKCE-gated). Confidential
+        # client_secret methods are still accepted by the library for
+        # maintainer-issued clients but not advertised.
+        self.assertEqual(data["token_endpoint_auth_methods_supported"], ["none"])
         # PKCE best practice: only S256.
         self.assertEqual(data["code_challenge_methods_supported"], ["S256"])
 


### PR DESCRIPTION
Closes #575.

## What this does

The MCP work (#644) added ``/oauth/docs/`` which already answered the original ask in #575: document the recommended flow and link to an implementation. Three things still tripped over each other across the doc and the discovery metadata; this PR reconciles them.

### Doc tone

The previous lead sentence read *\"TOSTI only supports the Authorization code grant type with PKCE\"*. That's stricter than reality (the library will technically accept other grant types) and the doc then promptly contradicted itself by mentioning a maintainer-issued ``client_credentials`` exception. Soften to advisory:

> **For any integration with TOSTI you should use the authorization-code grant with PKCE.** It's the flow our documentation, tooling and examples are written for, and the only one we'd recommend planning around.

Two other small misalignments fixed:

- The doc said *\"Both ``S256`` and ``plain`` code challenge methods are supported; pick ``S256``\"*. Discovery only advertises ``S256``; the doc's mention of ``plain`` was a relic. Now just says *\"Use the ``S256`` code-challenge method.\"*
- The account-page registration section claimed users got a confidential client with a ``client_secret`` they'd see at creation. ``views.py`` hard-codes ``CLIENT_PUBLIC`` &mdash; what users actually get is a ``client_id``, no secret. The doc now matches the code.
- The *\"ask a maintainer for client_credentials\"* section is collapsed into a single muted line at the end of the flow section. Maintainer-issued confidential clients are still possible out of band but it isn't a path users should plan around or discover from the docs.

### Discovery metadata (machine-readable)

Same policy applied to the RFC 8414 metadata as already applied to ``implicit`` / ``password``: advertise the recommended public surface, not the full library accept-list.

- ``grant_types_supported`` is now ``[\"authorization_code\", \"refresh_token\"]``. ``client_credentials`` removed.
- ``token_endpoint_auth_methods_supported`` is now ``[\"none\"]``. The confidential-client ``client_secret_post`` / ``client_secret_basic`` methods are still accepted by the library for maintainer-issued clients but aren't advertised.

The doc and the metadata now agree.

### Test coverage

The existing ``test_authorization_server_metadata_does_not_advertise_deprecated_grants`` test is renamed and broadened to lock in the new metadata shape exactly:

- ``grant_types_supported`` is exactly ``{authorization_code, refresh_token}``.
- ``response_types_supported`` is exactly ``[\"code\"]``.
- ``token_endpoint_auth_methods_supported`` is exactly ``[\"none\"]``.
- ``code_challenge_methods_supported`` is exactly ``[\"S256\"]``.

### README

Mirrors the doc's advisory language and links to ``/oauth/docs/``.

## Test plan

- [ ] CI: 216 tests pass, flake8 + black clean, OpenAPI schema validates.
- [ ] Visit ``/oauth/docs/`` and confirm: the lead sentence is advisory not absolute, the *\"Which flow to use\"* section names authorization-code + PKCE clearly, the *\"pick ``S256``\"* line no longer mentions ``plain``, the account-page registration section no longer promises a ``client_secret``.
- [ ] Fetch ``/.well-known/oauth-authorization-server`` and confirm the four advertised values match what the test asserts.
- [ ] Existing maintainer-issued confidential clients (Swagger, anything provisioned by hand) still work &mdash; the library still accepts the un-advertised auth methods.