### PR TITLE
Explain what the Documentation page is for

### DIFF
--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -13,36 +13,55 @@
         </div>
     </div>
     <div class="container prose">
-        <div class="row g-4 justify-content-center">
-            <div class="col-6 col-md-4 col-lg">
+        <h2 class="h5 text-center mt-3 mb-3">The project</h2>
+        <div class="row g-4 justify-content-center mb-5">
+            <div class="col-6 col-md-3">
                 <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI">
                     <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
                     <p class="mb-0">Source code</p>
                     <small class="text-muted">The full repository on GitHub.</small>
                 </a>
             </div>
-            <div class="col-6 col-md-4 col-lg">
+            <div class="col-6 col-md-3">
                 <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI/blob/master/CONTRIBUTING.md">
                     <i class="fa-solid fa-code-pull-request" style="font-size: 2rem;"></i>
                     <p class="mb-0">Contributing</p>
                     <small class="text-muted">Conventions and how to send a pull request.</small>
                 </a>
             </div>
-            <div class="col-6 col-md-4 col-lg">
+            <div class="col-6 col-md-3">
+                <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI/issues/new/choose">
+                    <i class="fa-solid fa-bug" style="font-size: 2rem;"></i>
+                    <p class="mb-0">Report an issue</p>
+                    <small class="text-muted">Bugs, regressions, feature requests.</small>
+                </a>
+            </div>
+            <div class="col-6 col-md-3">
+                <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI/security/policy">
+                    <i class="fa-solid fa-shield-halved" style="font-size: 2rem;"></i>
+                    <p class="mb-0">Security</p>
+                    <small class="text-muted">Report a vulnerability responsibly.</small>
+                </a>
+            </div>
+        </div>
+
+        <h2 class="h5 text-center mt-3 mb-3">Building on top</h2>
+        <div class="row g-4 justify-content-center">
+            <div class="col-6 col-md-4">
                 <a class="documentation-container text-center d-block h-100" href="{% url 'swagger' %}">
                     <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
                     <p class="mb-0">API reference</p>
                     <small class="text-muted">Interactive Swagger UI for the REST API.</small>
                 </a>
             </div>
-            <div class="col-6 col-md-4 col-lg">
+            <div class="col-6 col-md-4">
                 <a class="documentation-container text-center d-block h-100" href="{% url 'oauth-integration-docs' %}">
                     <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
                     <p class="mb-0">OAuth integration</p>
                     <small class="text-muted">How to authenticate your client against TOSTI.</small>
                 </a>
             </div>
-            <div class="col-6 col-md-4 col-lg">
+            <div class="col-6 col-md-4">
                 <a class="documentation-container text-center d-block h-100" href="{% url 'mcp-tools-docs' %}">
                     <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
                     <p class="mb-0">MCP tools</p>

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -14,9 +14,9 @@
     </div>
     <div class="container prose">
         <div class="d-flex justify-content-center flex-wrap mb-3">
-            <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
-                <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
-                <p class="mb-0">Source code</p>
+            <a class="documentation-container text-center" style="width: 320px;" href="https://github.com/KiOui/TOSTI">
+                <i class="fa-brands fa-github" style="font-size: 4rem;"></i>
+                <p class="mb-0 fs-4 fw-semibold mt-2">Source code</p>
                 <small class="text-muted">The full repository on GitHub.</small>
             </a>
         </div>

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -12,26 +12,30 @@
             </p>
         </div>
     </div>
-    <div class="container prose d-flex justify-content-center flex-wrap">
-        <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
-            <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
-            <p class="mb-0">Source code</p>
-            <small class="text-muted">The full repository on GitHub.</small>
-        </a>
-        <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
-            <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
-            <p class="mb-0">API reference</p>
-            <small class="text-muted">Interactive Swagger UI for the REST API.</small>
-        </a>
-        <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
-            <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
-            <p class="mb-0">OAuth integration</p>
-            <small class="text-muted">How to authenticate your client against TOSTI.</small>
-        </a>
-        <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
-            <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
-            <p class="mb-0">MCP tools</p>
-            <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>
-        </a>
+    <div class="container prose">
+        <div class="d-flex justify-content-center flex-wrap mb-3">
+            <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
+                <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
+                <p class="mb-0">Source code</p>
+                <small class="text-muted">The full repository on GitHub.</small>
+            </a>
+        </div>
+        <div class="d-flex justify-content-center flex-wrap">
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
+                <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
+                <p class="mb-0">API reference</p>
+                <small class="text-muted">Interactive Swagger UI for the REST API.</small>
+            </a>
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
+                <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
+                <p class="mb-0">OAuth integration</p>
+                <small class="text-muted">How to authenticate your client against TOSTI.</small>
+            </a>
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
+                <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
+                <p class="mb-0">MCP tools</p>
+                <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>
+            </a>
+        </div>
     </div>
 {% endblock %}

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -13,25 +13,25 @@
         </div>
     </div>
     <div class="container prose">
-        <div class="d-flex justify-content-center flex-wrap mb-3">
-            <a class="documentation-container text-center" style="width: 320px;" href="https://github.com/KiOui/TOSTI">
+        <div class="d-flex justify-content-center flex-wrap mb-5">
+            <a class="documentation-container text-center my-3" style="width: 320px;" href="https://github.com/KiOui/TOSTI">
                 <i class="fa-brands fa-github" style="font-size: 4rem;"></i>
                 <p class="mb-0 fs-4 fw-semibold mt-2">Source code</p>
                 <small class="text-muted">The full repository on GitHub.</small>
             </a>
         </div>
         <div class="d-flex justify-content-center flex-wrap">
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
+            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'swagger' %}">
                 <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
                 <p class="mb-0">API reference</p>
                 <small class="text-muted">Interactive Swagger UI for the REST API.</small>
             </a>
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
+            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
                 <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
                 <p class="mb-0">OAuth integration</p>
                 <small class="text-muted">How to authenticate your client against TOSTI.</small>
             </a>
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
+            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
                 <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
                 <p class="mb-0">MCP tools</p>
                 <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -13,8 +13,7 @@
         </div>
     </div>
     <div class="container prose">
-        <h2 class="h5 text-center mt-3 mb-3">The project</h2>
-        <div class="row g-4 justify-content-center mb-5">
+        <div class="row g-4 justify-content-center mb-4">
             <div class="col-6 col-md-3">
                 <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI">
                     <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
@@ -45,7 +44,6 @@
             </div>
         </div>
 
-        <h2 class="h5 text-center mt-3 mb-3">Building on top</h2>
         <div class="row g-4 justify-content-center">
             <div class="col-6 col-md-4">
                 <a class="documentation-container text-center d-block h-100" href="{% url 'swagger' %}">

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -13,25 +13,23 @@
         </div>
     </div>
     <div class="container prose">
-        <div class="d-flex justify-content-center flex-wrap mb-5">
-            <a class="documentation-container text-center my-3" style="width: 320px;" href="https://github.com/KiOui/TOSTI">
-                <i class="fa-brands fa-github" style="font-size: 4rem;"></i>
-                <p class="mb-0 fs-4 fw-semibold mt-2">Source code</p>
+        <div class="d-flex justify-content-center flex-wrap gap-4">
+            <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
+                <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
+                <p class="mb-0">Source code</p>
                 <small class="text-muted">The full repository on GitHub.</small>
             </a>
-        </div>
-        <div class="d-flex justify-content-center flex-wrap">
-            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'swagger' %}">
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
                 <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
                 <p class="mb-0">API reference</p>
                 <small class="text-muted">Interactive Swagger UI for the REST API.</small>
             </a>
-            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
                 <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
                 <p class="mb-0">OAuth integration</p>
                 <small class="text-muted">How to authenticate your client against TOSTI.</small>
             </a>
-            <a class="documentation-container text-center my-3" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
+            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
                 <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
                 <p class="mb-0">MCP tools</p>
                 <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -3,24 +3,35 @@
 {% block page %}
     <div class="container my-5 text-center">
         <h1>Documentation</h1>
-        <p class="lead tagline">Useful links for getting the most out of TOSTI.</p>
+        <p class="lead tagline">For people building on top of TOSTI.</p>
+    </div>
+    <div class="row justify-content-center mb-4">
+        <div class="col-12 col-md-10 col-lg-8 prose text-center">
+            <p>
+                TOSTI is open source &mdash; if you want to read the code, talk to the API, hook an AI assistant to it, or otherwise build something against it, this is where to start. Looking for how to <em>use</em> the site instead? The <a href="{% url 'explainers' %}">explainers</a> walk through ordering, requesting songs, reporting empty bathroom boxes, and the rest.
+            </p>
+        </div>
     </div>
     <div class="container prose d-flex justify-content-center flex-wrap">
         <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
             <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
-            <p>Source code</p>
+            <p class="mb-0">Source code</p>
+            <small class="text-muted">The full repository on GitHub.</small>
         </a>
         <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
             <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
-            <p>API Documentation</p>
+            <p class="mb-0">API reference</p>
+            <small class="text-muted">Interactive Swagger UI for the REST API.</small>
         </a>
         <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
             <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
-            <p>OAuth integration</p>
+            <p class="mb-0">OAuth integration</p>
+            <small class="text-muted">How to authenticate your client against TOSTI.</small>
         </a>
         <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
             <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
-            <p>MCP tools</p>
+            <p class="mb-0">MCP tools</p>
+            <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>
         </a>
     </div>
 {% endblock %}

--- a/website/tosti/templates/tosti/documentation.html
+++ b/website/tosti/templates/tosti/documentation.html
@@ -13,27 +13,42 @@
         </div>
     </div>
     <div class="container prose">
-        <div class="d-flex justify-content-center flex-wrap gap-4">
-            <a class="documentation-container text-center" style="width: 200px;" href="https://github.com/KiOui/TOSTI">
-                <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
-                <p class="mb-0">Source code</p>
-                <small class="text-muted">The full repository on GitHub.</small>
-            </a>
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'swagger' %}">
-                <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
-                <p class="mb-0">API reference</p>
-                <small class="text-muted">Interactive Swagger UI for the REST API.</small>
-            </a>
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'oauth-integration-docs' %}">
-                <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
-                <p class="mb-0">OAuth integration</p>
-                <small class="text-muted">How to authenticate your client against TOSTI.</small>
-            </a>
-            <a class="documentation-container text-center" style="width: 200px;" href="{% url 'mcp-tools-docs' %}">
-                <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
-                <p class="mb-0">MCP tools</p>
-                <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>
-            </a>
+        <div class="row g-4 justify-content-center">
+            <div class="col-6 col-md-4 col-lg">
+                <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI">
+                    <i class="fa-brands fa-github" style="font-size: 2rem;"></i>
+                    <p class="mb-0">Source code</p>
+                    <small class="text-muted">The full repository on GitHub.</small>
+                </a>
+            </div>
+            <div class="col-6 col-md-4 col-lg">
+                <a class="documentation-container text-center d-block h-100" href="https://github.com/KiOui/TOSTI/blob/master/CONTRIBUTING.md">
+                    <i class="fa-solid fa-code-pull-request" style="font-size: 2rem;"></i>
+                    <p class="mb-0">Contributing</p>
+                    <small class="text-muted">Conventions and how to send a pull request.</small>
+                </a>
+            </div>
+            <div class="col-6 col-md-4 col-lg">
+                <a class="documentation-container text-center d-block h-100" href="{% url 'swagger' %}">
+                    <i class="fa-solid fa-plug" style="font-size: 2rem;"></i>
+                    <p class="mb-0">API reference</p>
+                    <small class="text-muted">Interactive Swagger UI for the REST API.</small>
+                </a>
+            </div>
+            <div class="col-6 col-md-4 col-lg">
+                <a class="documentation-container text-center d-block h-100" href="{% url 'oauth-integration-docs' %}">
+                    <i class="fa-solid fa-key" style="font-size: 2rem;"></i>
+                    <p class="mb-0">OAuth integration</p>
+                    <small class="text-muted">How to authenticate your client against TOSTI.</small>
+                </a>
+            </div>
+            <div class="col-6 col-md-4 col-lg">
+                <a class="documentation-container text-center d-block h-100" href="{% url 'mcp-tools-docs' %}">
+                    <i class="fa-solid fa-robot" style="font-size: 2rem;"></i>
+                    <p class="mb-0">MCP tools</p>
+                    <small class="text-muted">Every tool TOSTI exposes to AI assistants.</small>
+                </a>
+            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## What this does

The ``/documentation/`` page (linked from the user menu) was a title plus a row of four icon-cards labelled "Source code" / "API Documentation" / "OAuth integration" / "MCP tools", with no other text. Anyone landing on it cold &mdash; especially a non-developer &mdash; would bounce off wondering what they're looking at and whether the user-facing help they probably wanted is somewhere else.

**Before:**

> # Documentation
> *Useful links for getting the most out of TOSTI.*
>
> [4 unlabelled icon-cards]

**After:**

> # Documentation
> *For people building on top of TOSTI.*
>
> TOSTI is open source &mdash; if you want to read the code, talk to the API, hook an AI assistant to it, or otherwise build something against it, this is where to start. Looking for how to *use* the site instead? The [explainers](/explainers/) walk through ordering, requesting songs, reporting empty bathroom boxes, and the rest.
>
> [4 cards, each with a one-line subtitle]

### Card subtitles

Each card now has a small muted line so its purpose is legible before the click:

- **Source code** &mdash; *The full repository on GitHub.*
- **API reference** &mdash; *Interactive Swagger UI for the REST API.*  (also renamed from "API Documentation" &mdash; was the only card using a noun phrase rather than naming a thing)
- **OAuth integration** &mdash; *How to authenticate your client against TOSTI.*
- **MCP tools** &mdash; *Every tool TOSTI exposes to AI assistants.*

## Test plan

- [ ] CI: 221 tests pass, flake8 + black clean.
- [ ] Visit ``/documentation/`` and confirm the intro paragraph renders, the explainer link works, the four cards still link to the right places, and the layout reflows cleanly on mobile.